### PR TITLE
Fix pygame window becoming unresponsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix `type_node is none` bug
 - Fix bugs in test_b_spline.py.
+- Fix pygame window unresponsive where events aren't handled
 
 ### Deprecated
 

--- a/tactics2d/sensor/render_manager.py
+++ b/tactics2d/sensor/render_manager.py
@@ -239,6 +239,11 @@ class RenderManager:
 
         self._clock.tick(self.fps)
 
+        # Handle pygame events to keep the window responsive
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                return
         blit_sequence = []
         for id_, layout_info in self._layouts.items():
             surface = pygame.transform.scale_by(self._sensors[id_].surface, layout_info[0])


### PR DESCRIPTION
I recently installed the library, and noticed that the pygame window for rendering parking would become unresponsive with any interaction with the window (E.g. minimising, moving, closing) on my machine (Windows 11).

I have updated the function to get these pygame events, and close the window if requested, which has fixed the hanging pygame window for me, I hope this is helpful.
