### PR TITLE
fix: correct reward typo in parking demo notebook

### DIFF
--- a/docs/tutorial/train_parking_demo.ipynb
+++ b/docs/tutorial/train_parking_demo.ipynb
@@ -1446,9 +1446,9 @@
    "source": [
     "start_t = time.time()\n",
     "agent.load(\"./data/parking_agent.pth\")\n",
-    "succ_rate, avg_reard = eval_rl_agent(env, agent, episode_num=100, verbose=False)\n",
+    "succ_rate, avg_reward = eval_rl_agent(env, agent, episode_num=100, verbose=False)\n",
     "print(\"Success rate: \", succ_rate)\n",
-    "print(\"Average reward: \", avg_reard)\n",
+    "print(\"Average reward: \", avg_reward)\n",
     "print(\"eval time: \", time.time() - start_t)"
    ]
   },


### PR DESCRIPTION
## Summary

This PR fixes a typo in `tutorial/train_parking_demo.ipynb`.

## Details

- corrected the spelling of `reward` in the notebook output/text