### PR TITLE
✨feat (parser): add native SUMO net.xml parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added a parser and corresponding tests, documentations for DriveInsightD dataset.
+- Added native SUMO `.net.xml` map parser (`NetXMLParser`) with junction geometry parsing, connection attachment, and junction shape auto-completion via convex hull.
+- Merged `Connection` class into `Junction` by flattening its properties directly into `Junction` with default values.
 
 ## [0.1.9rc3] - 2026-01-29
 

--- a/tactics2d/map/element/__init__.py
+++ b/tactics2d/map/element/__init__.py
@@ -5,7 +5,7 @@
 
 
 from .area import Area
-from .junction import Connection, Junction
+from .junction import Junction
 from .lane import Lane, LaneRelationship
 from .map import Map
 from .node import Node
@@ -17,7 +17,6 @@ __all__ = [
     "RoadLine",
     "Lane",
     "LaneRelationship",
-    "Connection",
     "Junction",
     "Area",
     "Map",

--- a/tactics2d/map/element/junction.py
+++ b/tactics2d/map/element/junction.py
@@ -90,3 +90,133 @@ class Junction:
             )
 
         self.connections[connection.id_] = connection
+#! python3
+# Copyright (C) 2024, Tactics2D Authors. Released under the GNU GPLv3.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Junction and Connection implementation."""
+
+import logging
+from typing import Optional
+
+
+class Connection:
+    """This class implements a connection between roads at a junction.
+
+    Supports both OpenDRIVE and SUMO connection semantics. OpenDRIVE-specific
+    fields (incoming_road, connecting_road, contact_point, lane_links) are used
+    when parsing .xodr files. SUMO-specific fields and any other format-specific
+    data are stored in custom_tags.
+
+    !!! quote "Reference"
+        [OpenDRIVE's description of a connection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
+        [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
+
+    Attributes:
+        id_ (str): The unique identifier of the connection.
+        incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
+        connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
+        contact_point (str): The contact point of the connection. Defaults to "start".
+        lane_links (list): The lane links of the connection. Each element is a
+            tuple of (from_lane_id, to_lane_id). Defaults to [].
+        custom_tags (dict): Format-specific metadata. For SUMO connections, stores
+            keys: from_edge, to_edge, from_lane, to_lane, via, dir, state.
+            Defaults to {}.
+    """
+
+    __slots__ = (
+        "id_",
+        "incoming_road",
+        "connecting_road",
+        "contact_point",
+        "lane_links",
+        "custom_tags",
+    )
+
+    def __init__(
+        self,
+        id_: str,
+        incoming_road: Optional[str] = None,
+        connecting_road: Optional[str] = None,
+        contact_point: str = "start",
+        lane_links: Optional[list] = None,
+        custom_tags: Optional[dict] = None,
+    ):
+        """Initialize the connection.
+
+        Args:
+            id_ (str): The unique identifier of the connection.
+            incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
+            connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
+            contact_point (str, optional): The contact point of the connection.
+                Defaults to "start".
+            lane_links (list, optional): The lane links of the connection.
+                Defaults to an empty list.
+            custom_tags (dict, optional): Format-specific metadata.
+                Defaults to an empty dict.
+        """
+        self.id_ = id_
+        self.incoming_road = incoming_road
+        self.connecting_road = connecting_road
+        self.contact_point = contact_point
+        self.lane_links = lane_links if lane_links is not None else []
+        self.custom_tags = custom_tags if custom_tags is not None else {}
+
+    def add_lane_link(self, lane_link: tuple):
+        """Add a lane link to the connection.
+
+        Args:
+            lane_link (tuple): The lane link to be added. Shape is (2,).
+                The first element is the id of the source lane and the second
+                element is the id of the destination lane.
+        """
+        self.lane_links.append(lane_link)
+
+
+class Junction:
+    """This class implements a junction.
+
+    !!! quote "Reference"
+        [OpenDRIVE's description of a junction](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
+        [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
+
+    Attributes:
+        id_ (str): The unique identifier of the junction.
+        connections (dict): The connections of the junction. Defaults to {}.
+        custom_tags (dict): Format-specific metadata. For SUMO junctions, stores
+            keys: sumo_id, x, y, type, shape. Defaults to {}.
+    """
+
+    __slots__ = ("id_", "connections", "custom_tags")
+
+    def __init__(
+        self,
+        id_: str,
+        connections: Optional[dict] = None,
+        custom_tags: Optional[dict] = None,
+    ):
+        """Initialize the junction.
+
+        Args:
+            id_ (str): The unique identifier of the junction.
+            connections (dict, optional): The connections of the junction.
+                Defaults to an empty dict.
+            custom_tags (dict, optional): Format-specific metadata.
+                Defaults to an empty dict.
+        """
+        self.id_ = id_
+        self.connections = connections if connections is not None else {}
+        self.custom_tags = custom_tags if custom_tags is not None else {}
+
+    def add_connection(self, connection: Connection):
+        """Add a connection to the junction.
+
+        Args:
+            connection (Connection): The connection to be added.
+        """
+        if connection.id_ in self.connections:
+            logging.warning(
+                f"Connection {connection.id_} already exists in junction "
+                f"{self.id_}. Overwriting the existing connection."
+            )
+        self.connections[connection.id_] = connection

--- a/tactics2d/map/element/junction.py
+++ b/tactics2d/map/element/junction.py
@@ -10,79 +10,56 @@ from typing import Optional
 class Junction:
     """This class implements a junction.
 
+    The junction absorbs the connection semantics previously held by a separate
+    Connection class.  OpenDRIVE-specific fields (``incoming_road``,
+    ``connecting_road``, ``contact_point``, ``lane_links``) are available
+    directly on every Junction instance and default to ``None`` / empty so
+    that junctions without explicit connection data (e.g. SUMO junctions that
+    only carry geometric shape information) can still be constructed without
+    supplying those fields.
+
+    Multiple connections belonging to the same physical junction are stored in
+    the ``connections`` dictionary, where each value is also a ``Junction``
+    instance carrying the per-connection attributes.
+
     !!! quote "Reference"
         [OpenDRIVE's description of a junction](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
         [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
 
     Attributes:
         id_ (str): The unique identifier of the junction.
-        connections (dict): The connections of the junction. Defaults to {}.
-        custom_tags (dict): Format-specific metadata. For SUMO junctions, stores
-            keys: sumo_id, x, y, type, shape. Defaults to {}.
+        incoming_road (str, optional): The id of the incoming road. Used in
+            OpenDRIVE connection semantics. Defaults to None.
+        connecting_road (str, optional): The id of the connecting road. Used in
+            OpenDRIVE connection semantics. Defaults to None.
+        contact_point (str): The contact point of the connection. Defaults to
+            ``"start"``.
+        lane_links (list): The lane links of the connection. Each element is a
+            tuple of (from_lane_id, to_lane_id). Defaults to [].
+        connections (dict): Child connections of the junction, keyed by their
+            ``id_``. Defaults to {}.
+        custom_tags (dict): Format-specific metadata. For SUMO junctions this
+            stores keys ``sumo_id``, ``x``, ``y``, ``type``, and ``shape``.
+            Defaults to {}.
     """
 
-    class Connection:
-        """This class implements a connection between roads at a junction.
-
-        Supports both OpenDRIVE and SUMO connection semantics. OpenDRIVE-specific
-        fields (incoming_road, connecting_road, contact_point, lane_links) are used
-        when parsing .xodr files. SUMO-specific fields and any other format-specific
-        data are stored in custom_tags.
-
-        !!! quote "Reference"
-            [OpenDRIVE's description of a connection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
-            [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
-
-        Attributes:
-            id_ (str): The unique identifier of the connection.
-            incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
-            connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
-            contact_point (str): The contact point of the connection. Defaults to "start".
-            lane_links (list): The lane links of the connection. Each element is a
-                tuple of (from_lane_id, to_lane_id). Defaults to [].
-            custom_tags (dict): Format-specific metadata. Defaults to {}.
-        """
-
-        __slots__ = (
-            "id_",
-            "incoming_road",
-            "connecting_road",
-            "contact_point",
-            "lane_links",
-            "custom_tags",
-        )
-
-        def __init__(
-            self,
-            id_: str,
-            incoming_road: Optional[str] = None,
-            connecting_road: Optional[str] = None,
-            contact_point: str = "start",
-            lane_links: Optional[list] = None,
-            custom_tags: Optional[dict] = None,
-        ):
-            self.id_ = id_
-            self.incoming_road = incoming_road
-            self.connecting_road = connecting_road
-            self.contact_point = contact_point
-            self.lane_links = lane_links if lane_links is not None else []
-            self.custom_tags = custom_tags if custom_tags is not None else {}
-
-        def add_lane_link(self, lane_link: tuple):
-            """Add a lane link to the connection.
-
-            Args:
-                lane_link (tuple): The lane link to be added. Shape is (2,).
-                    The first element is the id of the source lane and the second
-                    element is the id of the destination lane.
-            """
-            self.lane_links.append(lane_link)
-
-    __slots__ = ("id_", "connections", "custom_tags")
+    __slots__ = (
+        "id_",
+        "incoming_road",
+        "connecting_road",
+        "contact_point",
+        "lane_links",
+        "connections",
+        "custom_tags",
+    )
 
     def __init__(
         self,
         id_: str,
+        incoming_road: Optional[str] = None,
+        connecting_road: Optional[str] = None,
+        contact_point: str = "start",
+        lane_links: Optional[list] = None,
         connections: Optional[dict] = None,
         custom_tags: Optional[dict] = None,
     ):
@@ -90,24 +67,50 @@ class Junction:
 
         Args:
             id_ (str): The unique identifier of the junction.
-            connections (dict, optional): The connections of the junction.
+            incoming_road (str, optional): The id of the incoming road.
+                Defaults to None.
+            connecting_road (str, optional): The id of the connecting road.
+                Defaults to None.
+            contact_point (str, optional): The contact point of the connection.
+                Defaults to ``"start"``.
+            lane_links (list, optional): The lane links of the connection.
+                Defaults to an empty list.
+            connections (dict, optional): Child connections of the junction.
                 Defaults to an empty dict.
             custom_tags (dict, optional): Format-specific metadata.
                 Defaults to an empty dict.
         """
-        self.id_ = id_
-        self.connections = connections if connections is not None else {}
-        self.custom_tags = custom_tags if custom_tags is not None else {}
+        self.id_             = id_
+        self.incoming_road   = incoming_road
+        self.connecting_road = connecting_road
+        self.contact_point   = contact_point
+        self.lane_links      = lane_links if lane_links is not None else []
+        self.connections     = connections if connections is not None else {}
+        self.custom_tags     = custom_tags if custom_tags is not None else {}
 
-    def add_connection(self, connection: "Junction.Connection"):
-        """Add a connection to the junction.
+    def add_lane_link(self, lane_link: tuple):
+        """Add a lane link to the junction.
 
         Args:
-            connection (Junction.Connection): The connection to be added.
+            lane_link (tuple): The lane link to be added. Shape is (2,).
+                The first element is the id of the lane in the incoming road
+                and the second element is the id of the lane in the connecting
+                road.
+        """
+        self.lane_links.append(lane_link)
+
+    def add_connection(self, connection: "Junction"):
+        """Add a child connection to the junction.
+
+        Args:
+            connection (Junction): The connection to be added. Each connection
+                is itself a Junction instance carrying the per-connection
+                attributes (``incoming_road``, ``connecting_road``, etc.).
         """
         if connection.id_ in self.connections:
             logging.warning(
-                f"Connection {connection.id_} already exists in junction "
-                f"{self.id_}. Overwriting the existing connection."
+                "Connection %s already exists in junction %s. "
+                "Overwriting the existing connection.",
+                connection.id_, self.id_,
             )
         self.connections[connection.id_] = connection

--- a/tactics2d/map/element/junction.py
+++ b/tactics2d/map/element/junction.py
@@ -3,174 +3,8 @@
 
 """Junction implementation."""
 
-
-import logging
-
-
-class Connection:
-    """This class implements a connection.
-
-    !!! quote "Reference"
-        [OpenDRIVE's description of a connection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
-
-    Attributes:
-        id_ (str): The unique identifier of the connect. The id should be unique within the junction.
-        incoming_road (str): The id of the incoming road.
-        connecting_road (str): The id of the connecting road.
-        contact_point (str): The contact point of the junction. Defaults to "start".
-        lane_links (list): The lane links of the junction. Defaults to [].
-    """
-
-    __slots__ = ("id_", "incoming_road", "connecting_road", "contact_point", "lane_links")
-
-    def __init__(
-        self,
-        id_: str,
-        incoming_road: str,
-        connecting_road: str,
-        contact_point: str = "start",
-        lane_links: list = [],
-    ):
-        """Initialize the connection.
-
-        Args:
-            id_ (str): The unique identifier of the connect. The id should be unique within the junction.
-            incoming_road (str): The id of the incoming road.
-            connecting_road (str): The id of the connecting road.
-            contact_point (str, optional): The contact point of the junction.
-            lane_links (list, optional): The lane links of the junction.
-        """
-        self.id_ = id_
-        self.incoming_road = incoming_road
-        self.connecting_road = connecting_road
-        self.contact_point = contact_point
-        self.lane_links = lane_links
-
-    def add_lane_link(self, lane_link: tuple):
-        """Add a lane link to the junction.
-
-        Args:
-            lane_link (tuple): The lane link to be added. The shape is (2,). The first element is the id of the lane in the incoming road, and the second element is the id of the lane in the connecting road.
-        """
-        self.lane_links.append(lane_link)
-
-
-class Junction:
-    """This class implements a junction.
-
-    !!! quote "Reference"
-        [OpenDRIVE's description of a junction](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
-
-    Attributes:
-        id_ (str): The unique identifier of the junction.
-        connections (dict): The connections of the junction. Defaults to an empty dictionary.
-    """
-
-    __slots__ = ("id_", "connections")
-
-    def __init__(self, id_: str, connections: dict = {}):
-        """Initialize the junction.
-
-        Args:
-            id_ (str): The unique identifier of the junction.
-            connections (dict, optional): The connections of the junction. Defaults to an empty dictionary.
-        """
-        self.id_ = id_
-        self.connections = connections
-
-    def add_connection(self, connection: Connection):
-        """Add a connection to the junction.
-
-        Args:
-            connection (Connection): The connection to be added.
-        """
-        if connection.id_ in self.connections:
-            logging.warning(
-                f"Connection {connection.id_} already exists in junction {self.id_}. Overwrite the existing connection."
-            )
-
-        self.connections[connection.id_] = connection
-#! python3
-# Copyright (C) 2024, Tactics2D Authors. Released under the GNU GPLv3.
-# SPDX-License-Identifier: GPL-3.0-or-later
-
-"""Junction and Connection implementation."""
-
 import logging
 from typing import Optional
-
-
-class Connection:
-    """This class implements a connection between roads at a junction.
-
-    Supports both OpenDRIVE and SUMO connection semantics. OpenDRIVE-specific
-    fields (incoming_road, connecting_road, contact_point, lane_links) are used
-    when parsing .xodr files. SUMO-specific fields and any other format-specific
-    data are stored in custom_tags.
-
-    !!! quote "Reference"
-        [OpenDRIVE's description of a connection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
-        [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
-
-    Attributes:
-        id_ (str): The unique identifier of the connection.
-        incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
-        connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
-        contact_point (str): The contact point of the connection. Defaults to "start".
-        lane_links (list): The lane links of the connection. Each element is a
-            tuple of (from_lane_id, to_lane_id). Defaults to [].
-        custom_tags (dict): Format-specific metadata. For SUMO connections, stores
-            keys: from_edge, to_edge, from_lane, to_lane, via, dir, state.
-            Defaults to {}.
-    """
-
-    __slots__ = (
-        "id_",
-        "incoming_road",
-        "connecting_road",
-        "contact_point",
-        "lane_links",
-        "custom_tags",
-    )
-
-    def __init__(
-        self,
-        id_: str,
-        incoming_road: Optional[str] = None,
-        connecting_road: Optional[str] = None,
-        contact_point: str = "start",
-        lane_links: Optional[list] = None,
-        custom_tags: Optional[dict] = None,
-    ):
-        """Initialize the connection.
-
-        Args:
-            id_ (str): The unique identifier of the connection.
-            incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
-            connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
-            contact_point (str, optional): The contact point of the connection.
-                Defaults to "start".
-            lane_links (list, optional): The lane links of the connection.
-                Defaults to an empty list.
-            custom_tags (dict, optional): Format-specific metadata.
-                Defaults to an empty dict.
-        """
-        self.id_ = id_
-        self.incoming_road = incoming_road
-        self.connecting_road = connecting_road
-        self.contact_point = contact_point
-        self.lane_links = lane_links if lane_links is not None else []
-        self.custom_tags = custom_tags if custom_tags is not None else {}
-
-    def add_lane_link(self, lane_link: tuple):
-        """Add a lane link to the connection.
-
-        Args:
-            lane_link (tuple): The lane link to be added. Shape is (2,).
-                The first element is the id of the source lane and the second
-                element is the id of the destination lane.
-        """
-        self.lane_links.append(lane_link)
 
 
 class Junction:
@@ -186,6 +20,63 @@ class Junction:
         custom_tags (dict): Format-specific metadata. For SUMO junctions, stores
             keys: sumo_id, x, y, type, shape. Defaults to {}.
     """
+
+    class Connection:
+        """This class implements a connection between roads at a junction.
+
+        Supports both OpenDRIVE and SUMO connection semantics. OpenDRIVE-specific
+        fields (incoming_road, connecting_road, contact_point, lane_links) are used
+        when parsing .xodr files. SUMO-specific fields and any other format-specific
+        data are stored in custom_tags.
+
+        !!! quote "Reference"
+            [OpenDRIVE's description of a connection](https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/latest/specification/12_junctions/12_01_introduction.html)
+            [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
+
+        Attributes:
+            id_ (str): The unique identifier of the connection.
+            incoming_road (str, optional): The id of the incoming road. Used in OpenDRIVE.
+            connecting_road (str, optional): The id of the connecting road. Used in OpenDRIVE.
+            contact_point (str): The contact point of the connection. Defaults to "start".
+            lane_links (list): The lane links of the connection. Each element is a
+                tuple of (from_lane_id, to_lane_id). Defaults to [].
+            custom_tags (dict): Format-specific metadata. Defaults to {}.
+        """
+
+        __slots__ = (
+            "id_",
+            "incoming_road",
+            "connecting_road",
+            "contact_point",
+            "lane_links",
+            "custom_tags",
+        )
+
+        def __init__(
+            self,
+            id_: str,
+            incoming_road: Optional[str] = None,
+            connecting_road: Optional[str] = None,
+            contact_point: str = "start",
+            lane_links: Optional[list] = None,
+            custom_tags: Optional[dict] = None,
+        ):
+            self.id_ = id_
+            self.incoming_road = incoming_road
+            self.connecting_road = connecting_road
+            self.contact_point = contact_point
+            self.lane_links = lane_links if lane_links is not None else []
+            self.custom_tags = custom_tags if custom_tags is not None else {}
+
+        def add_lane_link(self, lane_link: tuple):
+            """Add a lane link to the connection.
+
+            Args:
+                lane_link (tuple): The lane link to be added. Shape is (2,).
+                    The first element is the id of the source lane and the second
+                    element is the id of the destination lane.
+            """
+            self.lane_links.append(lane_link)
 
     __slots__ = ("id_", "connections", "custom_tags")
 
@@ -208,11 +99,11 @@ class Junction:
         self.connections = connections if connections is not None else {}
         self.custom_tags = custom_tags if custom_tags is not None else {}
 
-    def add_connection(self, connection: Connection):
+    def add_connection(self, connection: "Junction.Connection"):
         """Add a connection to the junction.
 
         Args:
-            connection (Connection): The connection to be added.
+            connection (Junction.Connection): The connection to be added.
         """
         if connection.id_ in self.connections:
             logging.warning(

--- a/tactics2d/map/element/junction.py
+++ b/tactics2d/map/element/junction.py
@@ -80,13 +80,13 @@ class Junction:
             custom_tags (dict, optional): Format-specific metadata.
                 Defaults to an empty dict.
         """
-        self.id_             = id_
-        self.incoming_road   = incoming_road
+        self.id_ = id_
+        self.incoming_road = incoming_road
         self.connecting_road = connecting_road
-        self.contact_point   = contact_point
-        self.lane_links      = lane_links if lane_links is not None else []
-        self.connections     = connections if connections is not None else {}
-        self.custom_tags     = custom_tags if custom_tags is not None else {}
+        self.contact_point = contact_point
+        self.lane_links = lane_links if lane_links is not None else []
+        self.connections = connections if connections is not None else {}
+        self.custom_tags = custom_tags if custom_tags is not None else {}
 
     def add_lane_link(self, lane_link: tuple):
         """Add a lane link to the junction.

--- a/tactics2d/map/parser/__init__.py
+++ b/tactics2d/map/parser/__init__.py
@@ -7,5 +7,6 @@
 from .parse_gis import GISParser
 from .parse_osm import OSMParser
 from .parse_xodr import XODRParser
+from .parse_net_xml import NetXMLParser
 
-__all__ = ["GISParser", "OSMParser", "XODRParser"]
+__all__ = ["GISParser", "OSMParser", "XODRParser", "NetXMLParser"]

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -93,8 +93,8 @@ class NetXMLParser:
 
     def _load_lane(
         self,
-        lane_node:  ET.Element,
-        edge_type:  str,
+        lane_node: ET.Element,
+        edge_type: str,
         lane_width: float = None,
     ) -> tuple:
         """Parse one SUMO ``<lane>`` element into a Tactics2D Lane and its boundary RoadLines.
@@ -137,7 +137,7 @@ class NetXMLParser:
         half_width = (lane_width if lane_width is not None else self._DEFAULT_LANE_WIDTH) / 2.0
 
         center = LineString(shape)
-        left_geom = center.offset_curve( half_width)
+        left_geom = center.offset_curve(half_width)
         right_geom = center.offset_curve(-half_width)
 
         if left_geom is None or right_geom is None:

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -1,0 +1,246 @@
+# Copyright (C) 2024, Tactics2D Authors. Released under the GNU GPLv3.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""SUMO net.xml map parser implementation."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import defusedxml.ElementTree as ET
+from shapely.geometry import LineString
+
+from tactics2d.map.element import Junction, Lane, Map, RoadLine
+
+
+class NetXMLParser:
+    """This class implements a parser for the SUMO network format map (.net.xml).
+
+    The parser reads SUMO road network files and converts them into the tactics2d
+    internal map representation by directly parsing the XML without any external
+    SUMO dependencies. Edges and lanes are mapped to tactics2d Lane and RoadLine
+    objects, and junctions are mapped to tactics2d Junction objects.
+
+    !!! quote "Reference"
+        [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
+
+    Example:
+```python
+        from tactics2d.map.parser import NetXMLParser
+
+        parser = NetXMLParser()
+        map_ = parser.parse("/path/to/map.net.xml")
+        print(f"Loaded {len(map_.lanes)} lanes")
+```
+    """
+
+    _LANE_TYPE_DICT = {
+        "highway.motorway":    "highway",
+        "highway.trunk":       "highway",
+        "highway.primary":     "road",
+        "highway.secondary":   "road",
+        "highway.tertiary":    "road",
+        "highway.residential": "road",
+        "highway.service":     "road",
+        "highway.pedestrian":  "walkway",
+        "highway.footway":     "walkway",
+        "highway.cycleway":    "bicycle_lane",
+        "railway.rail":        "rail",
+        "railway.tram":        "tram",
+    }
+
+    _DEFAULT_LANE_WIDTH = 3.2
+
+    def __init__(self):
+        self._id_counter = 0
+
+    def _next_id(self) -> int:
+        uid = self._id_counter
+        self._id_counter += 1
+        return uid
+
+    def _parse_shape(self, shape_str: str) -> list:
+        """Parse a SUMO shape string into a list of (x, y) coordinate tuples.
+
+        Args:
+            shape_str (str): Space-separated coordinate pairs, e.g. '0.00,1.00 2.00,3.00'.
+
+        Returns:
+            list: List of (x, y) tuples parsed from the shape string.
+        """
+        points = []
+        for pair in shape_str.strip().split():
+            x, y = pair.split(",")
+            points.append((float(x), float(y)))
+        return points
+
+    def _get_lane_subtype(self, edge_type: str) -> str:
+        """Map a SUMO edge type string to a tactics2d lane subtype.
+
+        Args:
+            edge_type (str): The SUMO edge type attribute string.
+
+        Returns:
+            str: The corresponding tactics2d lane subtype. Defaults to 'road'.
+        """
+        return self._LANE_TYPE_DICT.get(edge_type, "road")
+
+    def _load_lane(self, lane_node: ET.Element, edge_type: str, lane_width: float = None) -> tuple:
+        """Parse one SUMO lane element into a tactics2d Lane and its boundary RoadLines.
+
+        The lane centre-line is taken directly from the shape attribute.
+        Left and right boundaries are computed by offsetting the centre-line
+        by half the default lane width.
+
+        Args:
+            lane_node (ET.Element): The ``<lane>`` XML element to parse.
+            edge_type (str): The type string of the parent edge.
+
+        Returns:
+            tuple: (Lane, left RoadLine, right RoadLine), or (None, None, None)
+                if the lane shape is missing or invalid.
+        """
+        shape_str = lane_node.attrib.get("shape", "")
+        if not shape_str:
+            return None, None, None
+
+        shape = self._parse_shape(shape_str)
+        if len(shape) < 2:
+            return None, None, None
+
+        speed_ms = float(lane_node.attrib.get("speed", "13.89"))
+        half_width = (lane_width if lane_width is not None else self._DEFAULT_LANE_WIDTH) / 2.0
+
+        center = LineString(shape)
+        left_geom  = center.offset_curve( half_width)
+        right_geom = center.offset_curve(-half_width)
+
+        if left_geom is None or right_geom is None:
+            return None, None, None
+
+        left_id  = self._next_id()
+        right_id = self._next_id()
+        lane_id  = self._next_id()
+
+        left_line = RoadLine(
+            id_=left_id,
+            geometry=left_geom,
+            type_="line_thin",
+            subtype="dashed",
+        )
+        right_line = RoadLine(
+            id_=right_id,
+            geometry=right_geom,
+            type_="line_thin",
+            subtype="dashed",
+        )
+        lane = Lane(
+            id_=lane_id,
+            left_side=left_geom,
+            right_side=right_geom,
+            subtype=self._get_lane_subtype(edge_type),
+            line_ids={"left": [left_id], "right": [right_id]},
+            speed_limit=round(speed_ms * 3.6, 3),
+            speed_limit_unit="km/h",
+        )
+
+        return lane, left_line, right_line
+
+    def _load_junction(self, junction_node: ET.Element) -> Junction:
+        """Parse a SUMO junction element into a tactics2d Junction.
+
+        Args:
+            junction_node (ET.Element): The ``<junction>`` XML element to parse.
+
+        Returns:
+            Junction: A tactics2d Junction object.
+        """
+        return Junction(id_=self._next_id())
+
+    def parse(self, file_path: str) -> Map:
+        """Parse a SUMO network file (.net.xml) into a tactics2d Map.
+
+        This function directly parses the XML without external SUMO dependencies,
+        mapping SUMO edges and lanes to tactics2d Lane and RoadLine objects,
+        and SUMO junctions to tactics2d Junction objects. Internal edges
+        (function="internal") are skipped as they represent junction internals
+        not needed for the road network topology.
+
+        Args:
+            file_path (str): The absolute path to the ``.net.xml`` file.
+
+        Returns:
+            Map: The parsed map containing all lanes, roadlines, and junctions.
+
+        Example:
+```python
+            from tactics2d.map.parser import NetXMLParser
+
+            parser = NetXMLParser()
+            map_ = parser.parse("/path/to/net.net.xml")
+
+            print(f"Loaded {len(map_.lanes)} lanes")
+            print(f"Loaded {len(map_.junctions)} junctions")
+```
+        """
+        xml_root = ET.parse(file_path).getroot()
+
+        map_name = os.path.splitext(os.path.basename(file_path))[0]
+        map_ = Map(name=map_name)
+
+        location_node = xml_root.find("location")
+        if location_node is not None:
+            boundary_str = location_node.attrib.get("convBoundary", "")
+            if boundary_str:
+                x_min, y_min, x_max, y_max = map(float, boundary_str.split(","))
+                map_.set_boundary((x_min, x_max, y_min, y_max))
+
+        for edge_node in xml_root.findall("edge"):
+            if edge_node.attrib.get("function") == "internal":
+                continue
+
+            edge_type = edge_node.attrib.get("type", "")
+
+            lane_nodes = edge_node.findall("lane")
+            # Calculate lane width from adjacent lane shapes when possible
+            lane_width = self._DEFAULT_LANE_WIDTH
+            if len(lane_nodes) >= 2:
+                try:
+                    shape0 = self._parse_shape(lane_nodes[0].attrib.get("shape", ""))
+                    shape1 = self._parse_shape(lane_nodes[1].attrib.get("shape", ""))
+                    if shape0 and shape1:
+                        dx = shape1[0][0] - shape0[0][0]
+                        dy = shape1[0][1] - shape0[0][1]
+                        computed = (dx**2 + dy**2) ** 0.5
+                        if 1.5 < computed < 6.0:
+                            lane_width = computed
+                except Exception:
+                    pass
+
+            for lane_node in lane_nodes:
+                try:
+                    lane, left_line, right_line = self._load_lane(lane_node, edge_type, lane_width)
+                    if lane is None:
+                        continue
+                    map_.add_lane(lane)
+                    map_.add_roadline(left_line)
+                    map_.add_roadline(right_line)
+                except Exception as exc:
+                    logging.warning(
+                        "Failed to parse lane %s: %s",
+                        lane_node.attrib.get("id", "unknown"), exc,
+                    )
+
+        for junction_node in xml_root.findall("junction"):
+            try:
+                junction = self._load_junction(junction_node)
+                map_.add_junction(junction)
+            except Exception as exc:
+                logging.warning(
+                    "Failed to parse junction %s: %s",
+                    junction_node.attrib.get("id", "unknown"), exc,
+                )
+
+        self._id_counter = 0
+        return map_

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -1,3 +1,4 @@
+#! python3
 # Copyright (C) 2024, Tactics2D Authors. Released under the GNU GPLv3.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,7 +12,7 @@ import os
 import defusedxml.ElementTree as ET
 from shapely.geometry import LineString
 
-from tactics2d.map.element import Junction, Lane, Map, RoadLine
+from tactics2d.map.element import Connection, Junction, Lane, Map, RoadLine
 
 
 class NetXMLParser:
@@ -20,7 +21,8 @@ class NetXMLParser:
     The parser reads SUMO road network files and converts them into the tactics2d
     internal map representation by directly parsing the XML without any external
     SUMO dependencies. Edges and lanes are mapped to tactics2d Lane and RoadLine
-    objects, and junctions are mapped to tactics2d Junction objects.
+    objects, junctions are mapped to tactics2d Junction objects, and connections
+    are attached to their corresponding junctions.
 
     !!! quote "Reference"
         [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
@@ -32,6 +34,7 @@ class NetXMLParser:
         parser = NetXMLParser()
         map_ = parser.parse("/path/to/map.net.xml")
         print(f"Loaded {len(map_.lanes)} lanes")
+        print(f"Loaded {len(map_.junctions)} junctions")
 ```
     """
 
@@ -91,11 +94,12 @@ class NetXMLParser:
 
         The lane centre-line is taken directly from the shape attribute.
         Left and right boundaries are computed by offsetting the centre-line
-        by half the default lane width.
+        by half the lane width.
 
         Args:
             lane_node (ET.Element): The ``<lane>`` XML element to parse.
             edge_type (str): The type string of the parent edge.
+            lane_width (float, optional): The lane width in metres.
 
         Returns:
             tuple: (Lane, left RoadLine, right RoadLine), or (None, None, None)
@@ -109,19 +113,19 @@ class NetXMLParser:
         if len(shape) < 2:
             return None, None, None
 
-        speed_ms = float(lane_node.attrib.get("speed", "13.89"))
+        speed_ms   = float(lane_node.attrib.get("speed", "13.89"))
         half_width = (lane_width if lane_width is not None else self._DEFAULT_LANE_WIDTH) / 2.0
 
-        center = LineString(shape)
+        center     = LineString(shape)
         left_geom  = center.offset_curve( half_width)
         right_geom = center.offset_curve(-half_width)
 
         if left_geom is None or right_geom is None:
             return None, None, None
 
-        left_id  = self._next_id()
-        right_id = self._next_id()
-        lane_id  = self._next_id()
+        left_id      = self._next_id()
+        right_id     = self._next_id()
+        lane_id      = self._next_id()
         lane_sumo_id = lane_node.attrib.get("id", "")
 
         left_line = RoadLine(
@@ -152,28 +156,69 @@ class NetXMLParser:
     def _load_junction(self, junction_node: ET.Element) -> Junction:
         """Parse a SUMO junction element into a tactics2d Junction.
 
+        Junction position, type, and shape polygon are stored in custom_tags.
+
         Args:
             junction_node (ET.Element): The ``<junction>`` XML element to parse.
 
         Returns:
             Junction: A tactics2d Junction object.
         """
-        return Junction(id_=self._next_id())
+        shape_str = junction_node.attrib.get("shape", "")
+        shape_pts = self._parse_shape(shape_str) if shape_str else []
+
+        return Junction(
+            id_=self._next_id(),
+            custom_tags={
+                "sumo_id": junction_node.attrib.get("id", ""),
+                "x":       junction_node.attrib.get("x", ""),
+                "y":       junction_node.attrib.get("y", ""),
+                "type":    junction_node.attrib.get("type", ""),
+                "shape":   shape_pts,
+            },
+        )
+
+    def _load_connection(self, conn_node: ET.Element) -> Connection:
+        """Parse a SUMO connection element into a tactics2d Connection.
+
+        SUMO connection attributes are stored in custom_tags:
+            from_edge, to_edge, from_lane, to_lane, via, dir, state.
+
+        Args:
+            conn_node (ET.Element): The ``<connection>`` XML element to parse.
+
+        Returns:
+            Connection: A tactics2d Connection object.
+        """
+        return Connection(
+            id_=self._next_id(),
+            custom_tags={
+                "from_edge": conn_node.attrib.get("from", ""),
+                "to_edge":   conn_node.attrib.get("to", ""),
+                "from_lane": conn_node.attrib.get("fromLane", ""),
+                "to_lane":   conn_node.attrib.get("toLane", ""),
+                "via":       conn_node.attrib.get("via", ""),
+                "dir":       conn_node.attrib.get("dir", ""),
+                "state":     conn_node.attrib.get("state", ""),
+            },
+        )
 
     def parse(self, file_path: str) -> Map:
         """Parse a SUMO network file (.net.xml) into a tactics2d Map.
 
         This function directly parses the XML without external SUMO dependencies,
         mapping SUMO edges and lanes to tactics2d Lane and RoadLine objects,
-        and SUMO junctions to tactics2d Junction objects. Internal edges
-        (function="internal") are skipped as they represent junction internals
-        not needed for the road network topology.
+        SUMO junctions to tactics2d Junction objects, and SUMO connections to
+        tactics2d Connection objects attached to their corresponding junctions.
+        Internal edges (function="internal") are skipped as they represent
+        junction internals not needed for the road network topology.
 
         Args:
             file_path (str): The absolute path to the ``.net.xml`` file.
 
         Returns:
-            Map: The parsed map containing all lanes, roadlines, and junctions.
+            Map: The parsed map containing all lanes, roadlines, junctions
+                and connections.
 
         Example:
 ```python
@@ -186,10 +231,11 @@ class NetXMLParser:
             print(f"Loaded {len(map_.junctions)} junctions")
 ```
         """
-        xml_root = ET.parse(file_path).getroot()
+        self._id_counter = 0
 
+        xml_root = ET.parse(file_path).getroot()
         map_name = os.path.splitext(os.path.basename(file_path))[0]
-        map_ = Map(name=map_name)
+        map_     = Map(name=map_name)
 
         location_node = xml_root.find("location")
         if location_node is not None:
@@ -198,22 +244,31 @@ class NetXMLParser:
                 x_min, y_min, x_max, y_max = map(float, boundary_str.split(","))
                 map_.set_boundary((x_min, x_max, y_min, y_max))
 
+        # edge id -> to-junction sumo id, used when attaching connections
+        edge_to_junction: dict[str, str] = {}
+        for edge_node in xml_root.findall("edge"):
+            if edge_node.attrib.get("function") == "internal":
+                continue
+            edge_id = edge_node.attrib.get("id", "")
+            to_node = edge_node.attrib.get("to", "")
+            if edge_id and to_node:
+                edge_to_junction[edge_id] = to_node
+
         for edge_node in xml_root.findall("edge"):
             if edge_node.attrib.get("function") == "internal":
                 continue
 
-            edge_type = edge_node.attrib.get("type", "")
-
+            edge_type  = edge_node.attrib.get("type", "")
             lane_nodes = edge_node.findall("lane")
-            # Calculate lane width from adjacent lane shapes when possible
+
             lane_width = self._DEFAULT_LANE_WIDTH
             if len(lane_nodes) >= 2:
                 try:
                     shape0 = self._parse_shape(lane_nodes[0].attrib.get("shape", ""))
                     shape1 = self._parse_shape(lane_nodes[1].attrib.get("shape", ""))
                     if shape0 and shape1:
-                        dx = shape1[0][0] - shape0[0][0]
-                        dy = shape1[0][1] - shape0[0][1]
+                        dx       = shape1[0][0] - shape0[0][0]
+                        dy       = shape1[0][1] - shape0[0][1]
                         computed = (dx**2 + dy**2) ** 0.5
                         if 1.5 < computed < 6.0:
                             lane_width = computed
@@ -222,7 +277,9 @@ class NetXMLParser:
 
             for lane_node in lane_nodes:
                 try:
-                    lane, left_line, right_line = self._load_lane(lane_node, edge_type, lane_width)
+                    lane, left_line, right_line = self._load_lane(
+                        lane_node, edge_type, lane_width
+                    )
                     if lane is None:
                         continue
                     map_.add_lane(lane)
@@ -234,15 +291,38 @@ class NetXMLParser:
                         lane_node.attrib.get("id", "unknown"), exc,
                     )
 
+        # sumo junction id -> tactics2d junction id, built while loading junctions
+        sumo_to_tactics_junction: dict[str, int] = {}
+
         for junction_node in xml_root.findall("junction"):
             try:
                 junction = self._load_junction(junction_node)
                 map_.add_junction(junction)
+                sumo_id = junction_node.attrib.get("id", "")
+                if sumo_id:
+                    sumo_to_tactics_junction[sumo_id] = junction.id_
             except Exception as exc:
                 logging.warning(
                     "Failed to parse junction %s: %s",
                     junction_node.attrib.get("id", "unknown"), exc,
                 )
+
+        for conn_node in xml_root.findall("connection"):
+            try:
+                connection   = self._load_connection(conn_node)
+                from_edge    = connection.custom_tags.get("from_edge", "")
+                sumo_junc_id = edge_to_junction.get(from_edge, "")
+                tactics_id   = sumo_to_tactics_junction.get(sumo_junc_id)
+
+                if tactics_id is not None and tactics_id in map_.junctions:
+                    map_.junctions[tactics_id].add_connection(connection)
+                else:
+                    logging.debug(
+                        "Cannot find junction for connection from_edge=%s; skipping.",
+                        from_edge,
+                    )
+            except Exception as exc:
+                logging.warning("Failed to parse connection: %s", exc)
 
         self._id_counter = 0
         return map_

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -11,7 +11,7 @@ import logging
 import os
 
 import defusedxml.ElementTree as ET
-from shapely.geometry import LineString
+from shapely.geometry import LineString, MultiPoint
 
 # Connection is a nested class of Junction; it is not exported separately.
 from tactics2d.map.element import Junction, Lane, Map, RoadLine
@@ -282,9 +282,6 @@ class NetXMLParser:
                 x_min, y_min, x_max, y_max = map(float, boundary_str.split(","))
                 map_.set_boundary((x_min, x_max, y_min, y_max))
 
-        # ------------------------------------------------------------------
-        # Pass 0: build edge-id → to-junction mapping for connection routing
-        # ------------------------------------------------------------------
         edge_to_junction: dict[str, str] = {}
         for edge_node in xml_root.findall("edge"):
             if edge_node.attrib.get("function") == "internal":
@@ -294,9 +291,6 @@ class NetXMLParser:
             if edge_id and to_node:
                 edge_to_junction[edge_id] = to_node
 
-        # ------------------------------------------------------------------
-        # Pass 1: edges → lanes + roadlines
-        # ------------------------------------------------------------------
         for edge_node in xml_root.findall("edge"):
             if edge_node.attrib.get("function") == "internal":
                 continue
@@ -304,7 +298,6 @@ class NetXMLParser:
             edge_type  = edge_node.attrib.get("type", "")
             lane_nodes = edge_node.findall("lane")
 
-            # Estimate lane width from the lateral distance between adjacent lanes
             lane_width = self._DEFAULT_LANE_WIDTH
             if len(lane_nodes) >= 2:
                 try:
@@ -335,10 +328,6 @@ class NetXMLParser:
                         lane_node.attrib.get("id", "unknown"), exc,
                     )
 
-        # ------------------------------------------------------------------
-        # Pass 2: junctions
-        # ------------------------------------------------------------------
-        # sumo junction id → tactics2d junction id, used when routing connections
         sumo_to_tactics_junction: dict[str, int] = {}
 
         for junction_node in xml_root.findall("junction"):
@@ -354,9 +343,6 @@ class NetXMLParser:
                     junction_node.attrib.get("id", "unknown"), exc,
                 )
 
-        # ------------------------------------------------------------------
-        # Pass 3: connections → attach to receiving junction
-        # ------------------------------------------------------------------
         for conn_node in xml_root.findall("connection"):
             try:
                 connection   = self._load_connection(conn_node)
@@ -373,6 +359,40 @@ class NetXMLParser:
                     )
             except Exception as exc:
                 logging.warning("Failed to parse connection: %s", exc)
+
+        junction_endpoints: dict[str, list] = {
+            sumo_id: [] for sumo_id in sumo_to_tactics_junction
+        }
+
+        for lane in map_.lanes.values():
+            edge_id = lane.custom_tags.get("sumo_id", "").rsplit("_", 1)[0]
+            to_sumo = edge_to_junction.get(edge_id)
+            if to_sumo and to_sumo in junction_endpoints:
+                try:
+                    for side in (lane.left_side, lane.right_side):
+                        coords = list(side.coords)
+                        junction_endpoints[to_sumo].append(coords[0])
+                        junction_endpoints[to_sumo].append(coords[-1])
+                except Exception:
+                    pass
+
+        for sumo_id, tactics_id in sumo_to_tactics_junction.items():
+            junction = map_.junctions.get(tactics_id)
+            if junction is None or junction.custom_tags.get("shape"):
+                continue
+
+            pts = junction_endpoints.get(sumo_id, [])
+            if len(pts) < 3:
+                continue
+
+            try:
+                hull = MultiPoint(pts).convex_hull
+                if hull.geom_type == "Polygon" and not hull.is_empty:
+                    junction.custom_tags["shape"] = list(hull.exterior.coords)
+            except Exception as exc:
+                logging.warning(
+                    "Failed to compute convex hull for junction %s: %s", sumo_id, exc
+                )
 
         self._id_counter = 0
         return map_

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -133,19 +133,19 @@ class NetXMLParser:
         if len(shape) < 2:
             return None, None, None
 
-        speed_ms   = float(lane_node.attrib.get("speed", "13.89"))
+        speed_ms = float(lane_node.attrib.get("speed", "13.89"))
         half_width = (lane_width if lane_width is not None else self._DEFAULT_LANE_WIDTH) / 2.0
 
-        center     = LineString(shape)
-        left_geom  = center.offset_curve( half_width)
+        center = LineString(shape)
+        left_geom = center.offset_curve( half_width)
         right_geom = center.offset_curve(-half_width)
 
         if left_geom is None or right_geom is None:
             return None, None, None
 
-        left_id      = self._next_id()
-        right_id     = self._next_id()
-        lane_id      = self._next_id()
+        left_id = self._next_id()
+        right_id = self._next_id()
+        lane_id = self._next_id()
         lane_sumo_id = lane_node.attrib.get("id", "")
 
         left_line = RoadLine(
@@ -276,7 +276,7 @@ class NetXMLParser:
 
         xml_root = ET.parse(file_path).getroot()
         map_name = os.path.splitext(os.path.basename(file_path))[0]
-        map_     = Map(name=map_name)
+        map_ = Map(name=map_name)
 
         location_node = xml_root.find("location")
         if location_node is not None:
@@ -298,7 +298,7 @@ class NetXMLParser:
             if edge_node.attrib.get("function") == "internal":
                 continue
 
-            edge_type  = edge_node.attrib.get("type", "")
+            edge_type = edge_node.attrib.get("type", "")
             lane_nodes = edge_node.findall("lane")
 
             lane_width = self._DEFAULT_LANE_WIDTH
@@ -307,8 +307,8 @@ class NetXMLParser:
                     shape0 = self._parse_shape(lane_nodes[0].attrib.get("shape", ""))
                     shape1 = self._parse_shape(lane_nodes[1].attrib.get("shape", ""))
                     if shape0 and shape1:
-                        dx       = shape1[0][0] - shape0[0][0]
-                        dy       = shape1[0][1] - shape0[0][1]
+                        dx = shape1[0][0] - shape0[0][0]
+                        dy = shape1[0][1] - shape0[0][1]
                         computed = (dx**2 + dy**2) ** 0.5
                         if 1.5 < computed < 6.0:
                             lane_width = computed
@@ -348,10 +348,10 @@ class NetXMLParser:
 
         for conn_node in xml_root.findall("connection"):
             try:
-                connection   = self._load_connection(conn_node)
-                from_edge    = connection.custom_tags.get("from_edge", "")
+                connection = self._load_connection(conn_node)
+                from_edge = connection.custom_tags.get("from_edge", "")
                 sumo_junc_id = edge_to_junction.get(from_edge, "")
-                tactics_id   = sumo_to_tactics_junction.get(sumo_junc_id)
+                tactics_id = sumo_to_tactics_junction.get(sumo_junc_id)
 
                 if tactics_id is not None and tactics_id in map_.junctions:
                     map_.junctions[tactics_id].add_connection(connection)

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -122,6 +122,7 @@ class NetXMLParser:
         left_id  = self._next_id()
         right_id = self._next_id()
         lane_id  = self._next_id()
+        lane_sumo_id = lane_node.attrib.get("id", "")
 
         left_line = RoadLine(
             id_=left_id,
@@ -143,6 +144,7 @@ class NetXMLParser:
             line_ids={"left": [left_id], "right": [right_id]},
             speed_limit=round(speed_ms * 3.6, 3),
             speed_limit_unit="km/h",
+            custom_tags={"sumo_id": lane_sumo_id},
         )
 
         return lane, left_line, right_line

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -1,8 +1,9 @@
 #! python3
 # Copyright (C) 2024, Tactics2D Authors. Released under the GNU GPLv3.
-# SPDX-License-Identifier: GPL-3.0-or-later
-
-"""SUMO net.xml map parser implementation."""
+# @File: parse_net_xml.py
+# @Description: This file defines a class for parsing the SUMO network map format.
+# @Author: Tactics2D Team
+# @Version: 1.0.0
 
 from __future__ import annotations
 
@@ -12,33 +13,33 @@ import os
 import defusedxml.ElementTree as ET
 from shapely.geometry import LineString
 
-from tactics2d.map.element import Connection, Junction, Lane, Map, RoadLine
+# Connection is a nested class of Junction; it is not exported separately.
+from tactics2d.map.element import Junction, Lane, Map, RoadLine
 
 
 class NetXMLParser:
-    """This class implements a parser for the SUMO network format map (.net.xml).
+    """Parser for the SUMO network format (.net.xml) map.
 
-    The parser reads SUMO road network files and converts them into the tactics2d
-    internal map representation by directly parsing the XML without any external
-    SUMO dependencies. Edges and lanes are mapped to tactics2d Lane and RoadLine
-    objects, junctions are mapped to tactics2d Junction objects, and connections
-    are attached to their corresponding junctions.
+    Reads a SUMO road-network file and converts it into a Tactics2D Map object
+    containing lanes, road-mark lines, junctions, and connections.  The parser
+    operates directly on the XML without any external SUMO dependency.
+
+    Edges and their child lanes are mapped to :class:`~tactics2d.map.element.Lane`
+    and :class:`~tactics2d.map.element.RoadLine` objects.  Junctions are mapped to
+    :class:`~tactics2d.map.element.Junction` objects and SUMO ``<connection>``
+    elements are attached to the junction at the receiving end of each edge.
+    Internal edges (``function="internal"``) are skipped.
 
     !!! quote "Reference"
         [SUMO Road Networks](https://sumo.dlr.de/docs/Networks/SUMO_Road_Networks.html)
 
     Example:
-```python
-        from tactics2d.map.parser import NetXMLParser
-
-        parser = NetXMLParser()
-        map_ = parser.parse("/path/to/map.net.xml")
-        print(f"Loaded {len(map_.lanes)} lanes")
-        print(f"Loaded {len(map_.junctions)} junctions")
-```
+        >>> parser = NetXMLParser()
+        >>> map_ = parser.parse("/path/to/map.net.xml")
+        >>> print(len(map_.lanes))
     """
 
-    _LANE_TYPE_DICT = {
+    _LANE_TYPE_DICT: dict = {
         "highway.motorway":    "highway",
         "highway.trunk":       "highway",
         "highway.primary":     "road",
@@ -53,9 +54,9 @@ class NetXMLParser:
         "railway.tram":        "tram",
     }
 
-    _DEFAULT_LANE_WIDTH = 3.2
+    _DEFAULT_LANE_WIDTH: float = 3.2
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._id_counter = 0
 
     def _next_id(self) -> int:
@@ -67,7 +68,8 @@ class NetXMLParser:
         """Parse a SUMO shape string into a list of (x, y) coordinate tuples.
 
         Args:
-            shape_str (str): Space-separated coordinate pairs, e.g. '0.00,1.00 2.00,3.00'.
+            shape_str (str): Space-separated coordinate pairs,
+                e.g. ``'0.00,1.00 2.00,3.00'``.
 
         Returns:
             list: List of (x, y) tuples parsed from the shape string.
@@ -79,31 +81,49 @@ class NetXMLParser:
         return points
 
     def _get_lane_subtype(self, edge_type: str) -> str:
-        """Map a SUMO edge type string to a tactics2d lane subtype.
+        """Map a SUMO edge type string to a Tactics2D lane subtype.
 
         Args:
-            edge_type (str): The SUMO edge type attribute string.
+            edge_type (str): The SUMO edge ``type`` attribute string.
 
         Returns:
-            str: The corresponding tactics2d lane subtype. Defaults to 'road'.
+            str: The corresponding Tactics2D lane subtype. Defaults to ``'road'``.
         """
         return self._LANE_TYPE_DICT.get(edge_type, "road")
 
-    def _load_lane(self, lane_node: ET.Element, edge_type: str, lane_width: float = None) -> tuple:
-        """Parse one SUMO lane element into a tactics2d Lane and its boundary RoadLines.
+    def _load_lane(
+        self,
+        lane_node:  ET.Element,
+        edge_type:  str,
+        lane_width: float = None,
+    ) -> tuple:
+        """Parse one SUMO ``<lane>`` element into a Tactics2D Lane and its boundary RoadLines.
 
-        The lane centre-line is taken directly from the shape attribute.
-        Left and right boundaries are computed by offsetting the centre-line
-        by half the lane width.
+        The lane centre-line is taken directly from the ``shape`` attribute.
+        Left and right boundaries are derived by offsetting the centre-line by
+        half the lane width using Shapely's ``offset_curve``.
 
         Args:
             lane_node (ET.Element): The ``<lane>`` XML element to parse.
-            edge_type (str): The type string of the parent edge.
-            lane_width (float, optional): The lane width in metres.
+            edge_type (str): The ``type`` string of the parent edge, used to
+                derive the lane subtype.
+            lane_width (float, optional): Override lane width in metres.
+                When ``None``, :attr:`_DEFAULT_LANE_WIDTH` is used.
 
         Returns:
-            tuple: (Lane, left RoadLine, right RoadLine), or (None, None, None)
-                if the lane shape is missing or invalid.
+            tuple:
+                lane (Lane or None): The constructed Lane, or ``None`` if the
+                    shape is missing or degenerate.
+                left_line (RoadLine or None): RoadLine for the left boundary.
+                right_line (RoadLine or None): RoadLine for the right boundary.
+
+        Example:
+            >>> parser = NetXMLParser()
+            >>> import xml.etree.ElementTree as ET
+            >>> lane_el = ET.fromstring(
+            ...     '<lane id="E0_0" speed="13.89" shape="0.00,0.00 10.00,0.00"/>'
+            ... )
+            >>> lane, left, right = parser._load_lane(lane_el, "highway.primary")
         """
         shape_str = lane_node.attrib.get("shape", "")
         if not shape_str:
@@ -154,15 +174,26 @@ class NetXMLParser:
         return lane, left_line, right_line
 
     def _load_junction(self, junction_node: ET.Element) -> Junction:
-        """Parse a SUMO junction element into a tactics2d Junction.
+        """Parse a SUMO ``<junction>`` element into a Tactics2D Junction.
 
-        Junction position, type, and shape polygon are stored in custom_tags.
+        Junction position, type, and shape polygon are stored in
+        ``custom_tags`` for use by visualisers and format converters.
 
         Args:
             junction_node (ET.Element): The ``<junction>`` XML element to parse.
 
         Returns:
-            Junction: A tactics2d Junction object.
+            Junction: A Tactics2D Junction object with SUMO metadata in
+                ``custom_tags``: keys ``sumo_id``, ``x``, ``y``, ``type``,
+                and ``shape`` (list of (x, y) tuples).
+
+        Example:
+            >>> parser = NetXMLParser()
+            >>> import xml.etree.ElementTree as ET
+            >>> junc_el = ET.fromstring(
+            ...     '<junction id="J0" x="10.0" y="0.0" type="priority" shape=""/>'
+            ... )
+            >>> junction = parser._load_junction(junc_el)
         """
         shape_str = junction_node.attrib.get("shape", "")
         shape_pts = self._parse_shape(shape_str) if shape_str else []
@@ -178,19 +209,32 @@ class NetXMLParser:
             },
         )
 
-    def _load_connection(self, conn_node: ET.Element) -> Connection:
-        """Parse a SUMO connection element into a tactics2d Connection.
+    def _load_connection(self, conn_node: ET.Element) -> Junction.Connection:
+        """Parse a SUMO ``<connection>`` element into a Tactics2D Connection.
 
-        SUMO connection attributes are stored in custom_tags:
-            from_edge, to_edge, from_lane, to_lane, via, dir, state.
+        All SUMO-specific routing attributes are stored in ``custom_tags`` so
+        that the Tactics2D core data model remains format-agnostic.
 
         Args:
             conn_node (ET.Element): The ``<connection>`` XML element to parse.
 
         Returns:
-            Connection: A tactics2d Connection object.
+            Junction.Connection: A Connection object whose ``custom_tags``
+                contain keys ``from_edge``, ``to_edge``, ``from_lane``,
+                ``to_lane``, ``via``, ``dir``, and ``state``.
+
+        Example:
+            >>> parser = NetXMLParser()
+            >>> import xml.etree.ElementTree as ET
+            >>> conn_el = ET.fromstring(
+            ...     '<connection from="E0" to="E1" fromLane="0" toLane="0"'
+            ...     ' via="" dir="s" state="M"/>'
+            ... )
+            >>> conn = parser._load_connection(conn_el)
+            >>> conn.custom_tags["dir"]
+            's'
         """
-        return Connection(
+        return Junction.Connection(
             id_=self._next_id(),
             custom_tags={
                 "from_edge": conn_node.attrib.get("from", ""),
@@ -204,32 +248,26 @@ class NetXMLParser:
         )
 
     def parse(self, file_path: str) -> Map:
-        """Parse a SUMO network file (.net.xml) into a tactics2d Map.
+        """Parse a SUMO network file (.net.xml) into a Tactics2D Map.
 
-        This function directly parses the XML without external SUMO dependencies,
-        mapping SUMO edges and lanes to tactics2d Lane and RoadLine objects,
-        SUMO junctions to tactics2d Junction objects, and SUMO connections to
-        tactics2d Connection objects attached to their corresponding junctions.
-        Internal edges (function="internal") are skipped as they represent
-        junction internals not needed for the road network topology.
+        The parser makes two linear passes over the XML: the first pass
+        builds all lanes and junctions; the second pass attaches each
+        ``<connection>`` to the junction at the receiving end of the
+        originating edge.  Internal edges (``function="internal"``) are
+        skipped throughout.
 
         Args:
-            file_path (str): The absolute path to the ``.net.xml`` file.
+            file_path (str): Absolute or relative path to the ``.net.xml`` file.
 
         Returns:
-            Map: The parsed map containing all lanes, roadlines, junctions
-                and connections.
+            Map: A Tactics2D Map populated with all lanes, roadlines, junctions,
+                and connections parsed from the SUMO network file.
 
         Example:
-```python
-            from tactics2d.map.parser import NetXMLParser
-
-            parser = NetXMLParser()
-            map_ = parser.parse("/path/to/net.net.xml")
-
-            print(f"Loaded {len(map_.lanes)} lanes")
-            print(f"Loaded {len(map_.junctions)} junctions")
-```
+            >>> parser = NetXMLParser()
+            >>> map_ = parser.parse("/path/to/map.net.xml")
+            >>> print(len(map_.lanes))
+            >>> print(len(map_.junctions))
         """
         self._id_counter = 0
 
@@ -244,7 +282,9 @@ class NetXMLParser:
                 x_min, y_min, x_max, y_max = map(float, boundary_str.split(","))
                 map_.set_boundary((x_min, x_max, y_min, y_max))
 
-        # edge id -> to-junction sumo id, used when attaching connections
+        # ------------------------------------------------------------------
+        # Pass 0: build edge-id → to-junction mapping for connection routing
+        # ------------------------------------------------------------------
         edge_to_junction: dict[str, str] = {}
         for edge_node in xml_root.findall("edge"):
             if edge_node.attrib.get("function") == "internal":
@@ -254,6 +294,9 @@ class NetXMLParser:
             if edge_id and to_node:
                 edge_to_junction[edge_id] = to_node
 
+        # ------------------------------------------------------------------
+        # Pass 1: edges → lanes + roadlines
+        # ------------------------------------------------------------------
         for edge_node in xml_root.findall("edge"):
             if edge_node.attrib.get("function") == "internal":
                 continue
@@ -261,6 +304,7 @@ class NetXMLParser:
             edge_type  = edge_node.attrib.get("type", "")
             lane_nodes = edge_node.findall("lane")
 
+            # Estimate lane width from the lateral distance between adjacent lanes
             lane_width = self._DEFAULT_LANE_WIDTH
             if len(lane_nodes) >= 2:
                 try:
@@ -291,7 +335,10 @@ class NetXMLParser:
                         lane_node.attrib.get("id", "unknown"), exc,
                     )
 
-        # sumo junction id -> tactics2d junction id, built while loading junctions
+        # ------------------------------------------------------------------
+        # Pass 2: junctions
+        # ------------------------------------------------------------------
+        # sumo junction id → tactics2d junction id, used when routing connections
         sumo_to_tactics_junction: dict[str, int] = {}
 
         for junction_node in xml_root.findall("junction"):
@@ -307,6 +354,9 @@ class NetXMLParser:
                     junction_node.attrib.get("id", "unknown"), exc,
                 )
 
+        # ------------------------------------------------------------------
+        # Pass 3: connections → attach to receiving junction
+        # ------------------------------------------------------------------
         for conn_node in xml_root.findall("connection"):
             try:
                 connection   = self._load_connection(conn_node)

--- a/tactics2d/map/parser/parse_net_xml.py
+++ b/tactics2d/map/parser/parse_net_xml.py
@@ -209,19 +209,22 @@ class NetXMLParser:
             },
         )
 
-    def _load_connection(self, conn_node: ET.Element) -> Junction.Connection:
-        """Parse a SUMO ``<connection>`` element into a Tactics2D Connection.
+    def _load_connection(self, conn_node: ET.Element) -> Junction:
+        """Parse a SUMO ``<connection>`` element into a Tactics2D Junction.
 
         All SUMO-specific routing attributes are stored in ``custom_tags`` so
-        that the Tactics2D core data model remains format-agnostic.
+        that the Tactics2D core data model remains format-agnostic.  The
+        returned object is a ``Junction`` instance whose connection-level
+        attributes (``incoming_road``, ``connecting_road``, etc.) are left at
+        their defaults; SUMO routing data is stored in ``custom_tags`` instead.
 
         Args:
             conn_node (ET.Element): The ``<connection>`` XML element to parse.
 
         Returns:
-            Junction.Connection: A Connection object whose ``custom_tags``
-                contain keys ``from_edge``, ``to_edge``, ``from_lane``,
-                ``to_lane``, ``via``, ``dir``, and ``state``.
+            Junction: A Junction instance whose ``custom_tags`` contain keys
+                ``from_edge``, ``to_edge``, ``from_lane``, ``to_lane``,
+                ``via``, ``dir``, and ``state``.
 
         Example:
             >>> parser = NetXMLParser()
@@ -234,7 +237,7 @@ class NetXMLParser:
             >>> conn.custom_tags["dir"]
             's'
         """
-        return Junction.Connection(
+        return Junction(
             id_=self._next_id(),
             custom_tags={
                 "from_edge": conn_node.attrib.get("from", ""),

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -78,11 +78,14 @@ def _signed_curvature(points: np.ndarray, s_vals: np.ndarray) -> np.ndarray:
         return np.zeros(n)
 
     ds2 = np.maximum(s[2:] - s[:-2], 1e-12)
-    dx = np.empty(n); dy = np.empty(n)
+    dx = np.empty(n)
+    dy = np.empty(n)
     dx[1:-1] = (pts[2:, 0] - pts[:-2, 0]) / ds2
     dy[1:-1] = (pts[2:, 1] - pts[:-2, 1]) / ds2
-    dx[0] = dx[1]; dy[0] = dy[1]
-    dx[-1] = dx[-2]; dy[-1] = dy[-2]
+    dx[0] = dx[1]
+    dy[0] = dy[1]
+    dx[-1] = dx[-2]
+    dy[-1] = dy[-2]
 
     ds_vec = np.maximum(np.gradient(s), 1e-12)
     d2x = np.gradient(dx) / ds_vec
@@ -392,11 +395,16 @@ class XODRParser:
 
     def _sample_geometry(self, node: ET.Element) -> list:
         """Dispatch to the appropriate sampler and remove trailing duplicate."""
-        if   node.find("line")       is not None: pts = self._sample_line(node)
-        elif node.find("spiral")     is not None: pts = self._sample_spiral(node)
-        elif node.find("arc")        is not None: pts = self._sample_arc(node)
-        elif node.find("poly3")      is not None: pts = self._sample_poly3(node)
-        elif node.find("paramPoly3") is not None: pts = self._sample_param_poly3(node)
+        if node.find("line") is not None:
+            pts = self._sample_line(node)
+        elif node.find("spiral") is not None:
+            pts = self._sample_spiral(node)
+        elif node.find("arc") is not None:
+            pts = self._sample_arc(node)
+        elif node.find("poly3") is not None:
+            pts = self._sample_poly3(node)
+        elif node.find("paramPoly3") is not None:
+            pts = self._sample_param_poly3(node)
         else:
             logging.warning("Unknown geometry type in planView; skipping.")
             return []
@@ -496,7 +504,7 @@ class XODRParser:
             type_=line_type,
             subtype=subtype,
             color=color,
-            width=rm.attrib.get("width")  if rm is not None else None,
+            width=rm.attrib.get("width") if rm is not None else None,
             height=rm.attrib.get("height") if rm is not None else None,
             lane_change=lane_change,
             temporary=False,
@@ -575,8 +583,8 @@ class XODRParser:
         location = type_node.attrib.get("type") if type_node is not None else None
 
         speed_node = lane_node.find("speed")
-        speed_limit = float(speed_node.attrib["max"])  if speed_node is not None and "max"  in speed_node.attrib else None
-        speed_limit_unit = speed_node.attrib["unit"]  if speed_node is not None and "unit" in speed_node.attrib else None
+        speed_limit = float(speed_node.attrib["max"]) if speed_node is not None and "max" in speed_node.attrib else None
+        speed_limit_unit = speed_node.attrib["unit"] if speed_node is not None and "unit" in speed_node.attrib else None
 
         width_records = self._parse_width_records(lane_node)
 
@@ -695,7 +703,7 @@ class XODRParser:
             return None
 
         shape = rotate(shape, rel_hdg, use_radians=True, origin=(0, 0))
-        shape = rotate(shape, heading,  use_radians=True, origin=(0, 0))
+        shape = rotate(shape, heading, use_radians=True, origin=(0, 0))
         shape = affine_transform(shape, [1, 0, 0, 1, x_origin, y_origin])
 
         return Area(id_=self._next_id(), geometry=shape, subtype=obj_type)
@@ -718,7 +726,7 @@ class XODRParser:
         road_id = road_node.attrib.get("id", "")
 
         raw_pts: list = []
-        raw_s:   list = []
+        raw_s: list = []
 
         for geom_node in road_node.find("planView").findall("geometry"):
             new_pts = self._sample_geometry(geom_node)
@@ -743,7 +751,7 @@ class XODRParser:
             return lanes, roadlines, objects
 
         pts_arr = np.array(raw_pts, dtype=np.float64)
-        s_arr = np.array(raw_s,   dtype=np.float64)
+        s_arr = np.array(raw_s, dtype=np.float64)
 
         dists = np.linalg.norm(np.diff(pts_arr, axis=0), axis=1)
         keep = np.concatenate([[True], dists > 0.02])
@@ -965,9 +973,12 @@ class XODRParser:
 
         for road_node in xml_root.findall("road"):
             lanes, roadlines, objects = self.load_road(road_node)
-            for lane     in lanes:     map_.add_lane(lane)
-            for roadline in roadlines: map_.add_roadline(roadline)
-            for obj      in objects:   map_.add_area(obj)
+            for lane in lanes:
+                map_.add_lane(lane)
+            for roadline in roadlines:
+                map_.add_roadline(roadline)
+            for obj in objects:
+                map_.add_area(obj)
 
         for junction_node in xml_root.findall("junction"):
             map_.add_junction(self.load_junction(junction_node))

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -20,9 +20,6 @@ from tactics2d.geometry import Circle
 from tactics2d.interpolator import ParamPoly3, Spiral
 
 
-# ---------------------------------------------------------------------------
-# Module-level geometry utilities
-# ---------------------------------------------------------------------------
 
 def _unit_left_normals(points: np.ndarray) -> np.ndarray:
     """Return the unit left-pointing normal at every sample of a polyline.
@@ -213,9 +210,6 @@ def _sanitise_linestring(pts: np.ndarray,
     return pts
 
 
-# ---------------------------------------------------------------------------
-# XODRParser
-# ---------------------------------------------------------------------------
 
 class XODRParser:
     """Parser for the OpenDRIVE (.xodr) map format.
@@ -258,9 +252,6 @@ class XODRParser:
         self._id_counter += 1
         return uid
 
-    # ------------------------------------------------------------------
-    # planView geometry samplers
-    # ------------------------------------------------------------------
 
     def _sample_line(self, node: ET.Element) -> list:
         """Sample a straight-line geometry at 0.1 m intervals.
@@ -414,9 +405,6 @@ class XODRParser:
             pts.pop()
         return pts
 
-    # ------------------------------------------------------------------
-    # Header
-    # ------------------------------------------------------------------
 
     def load_header(self, node: ET.Element) -> tuple:
         """Parse the ``<header>`` element of an OpenDRIVE file.
@@ -445,9 +433,6 @@ class XODRParser:
 
         return info, projector
 
-    # ------------------------------------------------------------------
-    # Road-mark factory
-    # ------------------------------------------------------------------
 
     def _make_roadline(self,
                        geometry: Union[list, LineString],
@@ -518,9 +503,6 @@ class XODRParser:
             custom_tags={"weight": rm.attrib.get("weight") if rm is not None else None},
         )
 
-    # ------------------------------------------------------------------
-    # Lane loading
-    # ------------------------------------------------------------------
 
     def _parse_width_records(self, lane_node: ET.Element) -> list:
         """Return width-polynomial records sorted by sOffset."""
@@ -645,9 +627,6 @@ class XODRParser:
 
         return lane, roadline, outer_t
 
-    # ------------------------------------------------------------------
-    # Object / area loading
-    # ------------------------------------------------------------------
 
     def _load_object(self,
                      ref_pts:  list,
@@ -721,9 +700,6 @@ class XODRParser:
 
         return Area(id_=self._next_id(), geometry=shape, subtype=obj_type)
 
-    # ------------------------------------------------------------------
-    # Road loading
-    # ------------------------------------------------------------------
 
     def load_road(self, road_node: ET.Element) -> tuple:
         """Parse a <road> element.
@@ -921,9 +897,6 @@ class XODRParser:
         hdgs.append(hdgs[-1])
         return hdgs
 
-    # ------------------------------------------------------------------
-    # Junction loading
-    # ------------------------------------------------------------------
 
     def load_junction(self, junction_node: ET.Element) -> Junction:
         """Parse a ``<junction>`` element and return a Junction object.
@@ -959,9 +932,6 @@ class XODRParser:
 
         return junction
 
-    # ------------------------------------------------------------------
-    # Top-level entry point
-    # ------------------------------------------------------------------
 
     def parse(self, file_path: str) -> Map:
         """Parse an OpenDRIVE file and return a Tactics2D Map object.

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -156,6 +156,9 @@ def _build_offset_polyline(
     collapsed = correction <= 0.0
     if np.any(collapsed):
         kappa_abs = np.abs(kappa)
+        # np.where evaluates both branches before selecting; suppress the
+        # divide-by-zero that occurs on straight segments (kappa_abs == 0)
+        # before the kappa_abs > 1e-6 mask is applied.
         with np.errstate(divide="ignore", invalid="ignore"):
             safe_t = np.where(
                 kappa_abs > 1e-6,
@@ -199,6 +202,8 @@ def _sanitise_linestring(pts: np.ndarray,
             pts = np.array(fixed.coords, dtype=np.float64)
         elif fixed.geom_type == "MultiLineString":
             longest = max(fixed.geoms, key=lambda g: g.length)
+            # Accept the repair only when the longest component retains at
+            # least 80% of the original length; otherwise keep the original.
             if longest.length >= 0.8 * ls.length:
                 pts = np.array(longest.coords, dtype=np.float64)
 
@@ -246,6 +251,7 @@ class XODRParser:
         uid = self._id_counter
         self._id_counter += 1
         return uid
+
 
     def _sample_line(self, node: ET.Element) -> list:
         """Sample a straight-line geometry at 0.1 m intervals.
@@ -399,6 +405,7 @@ class XODRParser:
             pts.pop()
         return pts
 
+
     def load_header(self, node: ET.Element) -> tuple:
         """Parse the ``<header>`` element of an OpenDRIVE file.
 
@@ -425,6 +432,7 @@ class XODRParser:
                 logging.warning("Could not parse geoReference CRS.")
 
         return info, projector
+
 
     def _make_roadline(self,
                        geometry: Union[list, LineString],
@@ -495,6 +503,7 @@ class XODRParser:
             custom_tags={"weight": rm.attrib.get("weight") if rm is not None else None},
         )
 
+
     def _parse_width_records(self, lane_node: ET.Element) -> list:
         """Return width-polynomial records sorted by sOffset."""
         records = [
@@ -533,9 +542,7 @@ class XODRParser:
 
         Args:
             lane_node (ET.Element): The ``<lane>`` XML element to parse.
-            type_node (ET.Element or None): The ``<type>`` XML element of the
-                parent road, or None if the road has no ``<type>`` element.
-                When None, the lane's ``location`` attribute is set to None.
+            type_node (ET.Element): The ``<type>`` XML element of the parent road.
             ref_pts (np.ndarray): Reference-line sample points. Shape is (N, 2).
             ref_s (np.ndarray): Arc-length values along the reference line. Shape is (N,).
             ref_normals (np.ndarray): Unit left-pointing normals of the reference line.
@@ -693,6 +700,7 @@ class XODRParser:
 
         return Area(id_=self._next_id(), geometry=shape, subtype=obj_type)
 
+
     def load_road(self, road_node: ET.Element) -> tuple:
         """Parse a <road> element.
 
@@ -708,12 +716,6 @@ class XODRParser:
         lanes, roadlines, objects = [], [], []
         type_node = road_node.find("type")
         road_id   = road_node.attrib.get("id", "")
-
-        if type_node is None:
-            logging.warning(
-                "Road %s has no <type> element; lane location will be set to None.",
-                road_id,
-            )
 
         raw_pts: list = []
         raw_s:   list = []
@@ -804,6 +806,12 @@ class XODRParser:
             if len(seg_center) < 2:
                 continue
 
+            # center_line is intentionally not added to roadlines. Its id_
+            # serves solely as the inner-boundary anchor (prev_id) for the
+            # first left/right lane of this section. The centre-lane geometry
+            # is emitted as per-roadMark sub-segments in the loop below.
+            # Known limitation: lane_ids referencing center_line.id_ cannot be
+            # resolved via map_.roadlines; consumers must be aware of this.
             center_line = RoadLine(
                 id_=self._next_id(),
                 geometry=LineString(seg_center.tolist()),
@@ -835,6 +843,12 @@ class XODRParser:
                 prev_id      = center_line.id_
 
                 for ln in left_lane_nodes:
+                    if type_node is None:
+                        logging.warning(
+                            "Road %s has no <type> element; skipping left lane %s.",
+                            road_id, ln.attrib.get("id", "?"),
+                        )
+                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
@@ -855,6 +869,12 @@ class XODRParser:
                 prev_id      = center_line.id_
 
                 for ln in right_lane_nodes:
+                    if type_node is None:
+                        logging.warning(
+                            "Road %s has no <type> element; skipping right lane %s.",
+                            road_id, ln.attrib.get("id", "?"),
+                        )
+                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
@@ -882,6 +902,7 @@ class XODRParser:
         hdgs = np.arctan2(diff[:, 1], diff[:, 0]).tolist()
         hdgs.append(hdgs[-1])
         return hdgs
+
 
     def load_junction(self, junction_node: ET.Element) -> Junction:
         """Parse a ``<junction>`` element and return a Junction object.
@@ -916,6 +937,7 @@ class XODRParser:
             junction.add_connection(connection)
 
         return junction
+
 
     def parse(self, file_path: str) -> Map:
         """Parse an OpenDRIVE file and return a Tactics2D Map object.

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -514,16 +514,18 @@ class XODRParser:
 
     def _parse_width_records(self, lane_node: ET.Element) -> list:
         """Return width-polynomial records sorted by sOffset."""
-        records = [
-            {
-                "sOffset": float(w.attrib["sOffset"]),
-                "a": float(w.attrib["a"]),
-                "b": float(w.attrib["b"]),
-                "c": float(w.attrib["c"]),
-                "d": float(w.attrib["d"]),
-            }
-            for w in lane_node.findall("width")
-        ]
+        records = []
+        for w in lane_node.findall("width"):
+            try:
+                records.append({
+                    "sOffset": float(w.attrib.get("sOffset", 0.0)),
+                    "a": float(w.attrib["a"]),
+                    "b": float(w.attrib["b"]),
+                    "c": float(w.attrib["c"]),
+                    "d": float(w.attrib["d"]),
+                })
+            except KeyError:
+                pass
         records.sort(key=lambda r: r["sOffset"])
         return records
 
@@ -851,12 +853,6 @@ class XODRParser:
                 prev_id = center_line.id_
 
                 for ln in left_lane_nodes:
-                    if type_node is None:
-                        logging.warning(
-                            "Road %s has no <type> element; skipping left lane %s.",
-                            road_id, ln.attrib.get("id", "?"),
-                        )
-                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
@@ -877,12 +873,6 @@ class XODRParser:
                 prev_id = center_line.id_
 
                 for ln in right_lane_nodes:
-                    if type_node is None:
-                        logging.warning(
-                            "Road %s has no <type> element; skipping right lane %s.",
-                            road_id, ln.attrib.get("id", "?"),
-                        )
-                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -44,8 +44,8 @@ def _unit_left_normals(points: np.ndarray) -> np.ndarray:
 
     tangents = np.empty_like(pts)
     tangents[1:-1] = pts[2:] - pts[:-2]
-    tangents[0]    = pts[1]  - pts[0]
-    tangents[-1]   = pts[-1] - pts[-2]
+    tangents[0] = pts[1] - pts[0]
+    tangents[-1] = pts[-1] - pts[-2]
 
     norms = np.linalg.norm(tangents, axis=1, keepdims=True)
     norms = np.where(norms < 1e-12, 1.0, norms)
@@ -72,8 +72,8 @@ def _signed_curvature(points: np.ndarray, s_vals: np.ndarray) -> np.ndarray:
             values indicate left curvature, negative values indicate right curvature.
     """
     pts = np.asarray(points, dtype=np.float64)
-    s   = np.asarray(s_vals,  dtype=np.float64)
-    n   = len(pts)
+    s = np.asarray(s_vals,  dtype=np.float64)
+    n = len(pts)
     if n < 3:
         return np.zeros(n)
 
@@ -262,10 +262,10 @@ class XODRParser:
         Returns:
             list: List of (x, y) world-coordinate tuples sampled along the line.
         """
-        x0  = float(node.attrib["x"])
-        y0  = float(node.attrib["y"])
+        x0 = float(node.attrib["x"])
+        y0 = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
-        L   = float(node.attrib["length"])
+        L = float(node.attrib["length"])
 
         if L <= 0.0:
             return [(x0, y0)]
@@ -283,12 +283,12 @@ class XODRParser:
         Returns:
             list: List of (x, y) world-coordinate tuples sampled along the spiral.
         """
-        x0  = float(node.attrib["x"])
-        y0  = float(node.attrib["y"])
+        x0 = float(node.attrib["x"])
+        y0 = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
-        L   = float(node.attrib["length"])
-        k0  = float(node.find("spiral").attrib["curvStart"])
-        k1  = float(node.find("spiral").attrib["curvEnd"])
+        L = float(node.attrib["length"])
+        k0 = float(node.find("spiral").attrib["curvStart"])
+        k1 = float(node.find("spiral").attrib["curvEnd"])
 
         if L < 1e-6:
             return [(x0, y0)]
@@ -309,11 +309,11 @@ class XODRParser:
         Returns:
             list: List of (x, y) world-coordinate tuples sampled along the arc.
         """
-        x0  = float(node.attrib["x"])
-        y0  = float(node.attrib["y"])
+        x0 = float(node.attrib["x"])
+        y0 = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
-        L   = float(node.attrib["length"])
-        k   = float(node.find("arc").attrib["curvature"])
+        L = float(node.attrib["length"])
+        k = float(node.find("arc").attrib["curvature"])
 
         if abs(k) < 1e-9:
             return self._sample_line(node)
@@ -325,9 +325,9 @@ class XODRParser:
             radius=r,
             side="L" if k > 0 else "R",
         )
-        arc_angle   = L / radius
+        arc_angle = L / radius
         start_angle = hdg - np.pi / 2.0 * np.sign(k)
-        clockwise   = k < 0
+        clockwise = k < 0
 
         pts = Circle.get_arc(
             center_point=center,
@@ -348,11 +348,11 @@ class XODRParser:
         Returns:
             list: List of (x, y) world-coordinate tuples sampled along the curve.
         """
-        x0  = float(node.attrib["x"])
-        y0  = float(node.attrib["y"])
+        x0 = float(node.attrib["x"])
+        y0 = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
-        L   = float(node.attrib["length"])
-        p   = node.find("poly3")
+        L = float(node.attrib["length"])
+        p = node.find("poly3")
         a, b, c, d = (float(p.attrib[k]) for k in ("a", "b", "c", "d"))
 
         n = max(2, int(L / 0.1) + 1)
@@ -374,11 +374,11 @@ class XODRParser:
         Returns:
             list: List of (x, y) world-coordinate tuples sampled along the curve.
         """
-        x0      = float(node.attrib["x"])
-        y0      = float(node.attrib["y"])
-        hdg     = float(node.attrib["hdg"])
-        L       = float(node.attrib["length"])
-        p       = node.find("paramPoly3")
+        x0 = float(node.attrib["x"])
+        y0 = float(node.attrib["y"])
+        hdg = float(node.attrib["hdg"])
+        L = float(node.attrib["length"])
+        p = node.find("paramPoly3")
         p_range = p.attrib.get("pRange", "normalized")
         c = {k: float(p.attrib[k]) for k in ("aU","bU","cU","dU","aV","bV","cV","dV")}
 
@@ -460,20 +460,20 @@ class XODRParser:
 
         if rm_type == "none":
             line_type = "virtual"
-            subtype   = None
+            subtype = None
         elif rm_type == "curb":
             line_type = "curbstone"
-            subtype   = None
+            subtype = None
         elif rm_type == "edge":
             line_type = "road_border"
-            subtype   = None
+            subtype = None
         elif rm_type == "grass":
             line_type = "grass"
-            subtype   = None
+            subtype = None
         else:
             width_val = float(rm.attrib.get("width", "0.15")) if rm is not None else 0.15
             line_type = "line_thin" if width_val <= 0.15 else "line_thick"
-            subtype   = self._ROADMARK_SUBTYPE.get(rm_type)
+            subtype = self._ROADMARK_SUBTYPE.get(rm_type)
 
         color_raw = rm.attrib.get("color") if rm is not None else None
         color_map = {"standard": "white", "violet": "purple"}
@@ -574,9 +574,9 @@ class XODRParser:
 
         location = type_node.attrib.get("type") if type_node is not None else None
 
-        speed_node       = lane_node.find("speed")
-        speed_limit      = float(speed_node.attrib["max"])  if speed_node is not None and "max"  in speed_node.attrib else None
-        speed_limit_unit =       speed_node.attrib["unit"]  if speed_node is not None and "unit" in speed_node.attrib else None
+        speed_node = lane_node.find("speed")
+        speed_limit = float(speed_node.attrib["max"])  if speed_node is not None and "max"  in speed_node.attrib else None
+        speed_limit_unit = speed_node.attrib["unit"]  if speed_node is not None and "unit" in speed_node.attrib else None
 
         width_records = self._parse_width_records(lane_node)
 
@@ -599,10 +599,10 @@ class XODRParser:
         outer_coords = outer_pts.tolist()
 
         if sign > 0:
-            left_geom  = LineString(outer_coords)
+            left_geom = LineString(outer_coords)
             right_geom = LineString(inner_coords)
         else:
-            left_geom  = LineString(inner_coords)
+            left_geom = LineString(inner_coords)
             right_geom = LineString(outer_coords)
 
         roadline = self._make_roadline(outer_coords, lane_node.find("roadMark"))
@@ -643,18 +643,18 @@ class XODRParser:
         t = float(obj_node.attrib["t"])
 
         idx = int(np.argmin(np.abs(s_vals - s)))
-        heading  = headings[idx]
-        x, y     = ref_pts[idx]
+        heading = headings[idx]
+        x, y = ref_pts[idx]
         x_origin = x - t * np.sin(heading)
         y_origin = y + t * np.cos(heading)
-        rel_hdg  = float(obj_node.attrib.get("hdg", 0.0))
+        rel_hdg = float(obj_node.attrib.get("hdg", 0.0))
 
         shape = None
 
         outline = obj_node.find("outline")
         if outline is not None:
             global_corners = outline.findall("cornerGlobal")
-            local_corners  = outline.findall("cornerLocal")
+            local_corners = outline.findall("cornerLocal")
 
             if global_corners:
                 poly_pts = [
@@ -715,7 +715,7 @@ class XODRParser:
         """
         lanes, roadlines, objects = [], [], []
         type_node = road_node.find("type")
-        road_id   = road_node.attrib.get("id", "")
+        road_id = road_node.attrib.get("id", "")
 
         raw_pts: list = []
         raw_s:   list = []
@@ -743,12 +743,12 @@ class XODRParser:
             return lanes, roadlines, objects
 
         pts_arr = np.array(raw_pts, dtype=np.float64)
-        s_arr   = np.array(raw_s,   dtype=np.float64)
+        s_arr = np.array(raw_s,   dtype=np.float64)
 
         dists = np.linalg.norm(np.diff(pts_arr, axis=0), axis=1)
-        keep  = np.concatenate([[True], dists > 0.02])
+        keep = np.concatenate([[True], dists > 0.02])
         pts_arr = pts_arr[keep]
-        s_arr   = s_arr[keep]
+        s_arr = s_arr[keep]
         if len(pts_arr) < 2:
             return lanes, roadlines, objects
 
@@ -779,9 +779,9 @@ class XODRParser:
 
         center_pts = pts_arr + lane_offset_t[:, np.newaxis] * ref_normals
 
-        ls_nodes    = lanes_node.findall("laneSection")
+        ls_nodes = lanes_node.findall("laneSection")
         ls_s_starts = [float(ls.attrib["s"]) for ls in ls_nodes]
-        ls_s_ends   = ls_s_starts[1:] + [float(s_arr[-1])]
+        ls_s_ends = ls_s_starts[1:] + [float(s_arr[-1])]
 
         eps = 1e-6
 
@@ -798,10 +798,10 @@ class XODRParser:
                 continue
 
             seg_ref_pts = pts_arr[mask]
-            seg_ref_s   = s_arr[mask]
-            seg_ref_n   = ref_normals[mask]
-            seg_lo_t    = lane_offset_t[mask]
-            seg_center  = center_pts[mask]
+            seg_ref_s = s_arr[mask]
+            seg_ref_n = ref_normals[mask]
+            seg_lo_t = lane_offset_t[mask]
+            seg_center = center_pts[mask]
 
             if len(seg_center) < 2:
                 continue
@@ -818,9 +818,9 @@ class XODRParser:
             )
 
             center_lane_node = ls_node.find("center").find("lane")
-            rm_nodes        = center_lane_node.findall("roadMark")
+            rm_nodes = center_lane_node.findall("roadMark")
             rm_s_abs_starts = [ls_s0 + float(rm.attrib["sOffset"]) for rm in rm_nodes]
-            rm_s_abs_ends   = rm_s_abs_starts[1:] + [float(seg_ref_s[-1])]
+            rm_s_abs_ends = rm_s_abs_starts[1:] + [float(seg_ref_s[-1])]
 
             for rm_i, rm_node in enumerate(rm_nodes):
                 rm_abs_s0 = rm_s_abs_starts[rm_i]
@@ -840,7 +840,7 @@ class XODRParser:
                     key=lambda n: int(n.attrib["id"])
                 )
                 cumulative_t = seg_lo_t.copy()
-                prev_id      = center_line.id_
+                prev_id = center_line.id_
 
                 for ln in left_lane_nodes:
                     if type_node is None:
@@ -866,7 +866,7 @@ class XODRParser:
                     key=lambda n: abs(int(n.attrib["id"]))
                 )
                 cumulative_t = seg_lo_t.copy()
-                prev_id      = center_line.id_
+                prev_id = center_line.id_
 
                 for ln in right_lane_nodes:
                     if type_node is None:

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -156,9 +156,6 @@ def _build_offset_polyline(
     collapsed = correction <= 0.0
     if np.any(collapsed):
         kappa_abs = np.abs(kappa)
-        # np.where evaluates both branches before selecting; suppress the
-        # divide-by-zero that occurs on straight segments (kappa_abs == 0)
-        # before the kappa_abs > 1e-6 mask is applied.
         with np.errstate(divide="ignore", invalid="ignore"):
             safe_t = np.where(
                 kappa_abs > 1e-6,
@@ -202,8 +199,6 @@ def _sanitise_linestring(pts: np.ndarray,
             pts = np.array(fixed.coords, dtype=np.float64)
         elif fixed.geom_type == "MultiLineString":
             longest = max(fixed.geoms, key=lambda g: g.length)
-            # Accept the repair only when the longest component retains at
-            # least 80% of the original length; otherwise keep the original.
             if longest.length >= 0.8 * ls.length:
                 pts = np.array(longest.coords, dtype=np.float64)
 
@@ -251,7 +246,6 @@ class XODRParser:
         uid = self._id_counter
         self._id_counter += 1
         return uid
-
 
     def _sample_line(self, node: ET.Element) -> list:
         """Sample a straight-line geometry at 0.1 m intervals.
@@ -405,7 +399,6 @@ class XODRParser:
             pts.pop()
         return pts
 
-
     def load_header(self, node: ET.Element) -> tuple:
         """Parse the ``<header>`` element of an OpenDRIVE file.
 
@@ -432,7 +425,6 @@ class XODRParser:
                 logging.warning("Could not parse geoReference CRS.")
 
         return info, projector
-
 
     def _make_roadline(self,
                        geometry: Union[list, LineString],
@@ -503,7 +495,6 @@ class XODRParser:
             custom_tags={"weight": rm.attrib.get("weight") if rm is not None else None},
         )
 
-
     def _parse_width_records(self, lane_node: ET.Element) -> list:
         """Return width-polynomial records sorted by sOffset."""
         records = [
@@ -542,7 +533,9 @@ class XODRParser:
 
         Args:
             lane_node (ET.Element): The ``<lane>`` XML element to parse.
-            type_node (ET.Element): The ``<type>`` XML element of the parent road.
+            type_node (ET.Element or None): The ``<type>`` XML element of the
+                parent road, or None if the road has no ``<type>`` element.
+                When None, the lane's ``location`` attribute is set to None.
             ref_pts (np.ndarray): Reference-line sample points. Shape is (N, 2).
             ref_s (np.ndarray): Arc-length values along the reference line. Shape is (N,).
             ref_normals (np.ndarray): Unit left-pointing normals of the reference line.
@@ -700,7 +693,6 @@ class XODRParser:
 
         return Area(id_=self._next_id(), geometry=shape, subtype=obj_type)
 
-
     def load_road(self, road_node: ET.Element) -> tuple:
         """Parse a <road> element.
 
@@ -716,6 +708,12 @@ class XODRParser:
         lanes, roadlines, objects = [], [], []
         type_node = road_node.find("type")
         road_id   = road_node.attrib.get("id", "")
+
+        if type_node is None:
+            logging.warning(
+                "Road %s has no <type> element; lane location will be set to None.",
+                road_id,
+            )
 
         raw_pts: list = []
         raw_s:   list = []
@@ -837,12 +835,6 @@ class XODRParser:
                 prev_id      = center_line.id_
 
                 for ln in left_lane_nodes:
-                    if type_node is None:
-                        logging.warning(
-                            "Road %s has no <type> element; skipping left lane %s.",
-                            road_id, ln.attrib.get("id", "?"),
-                        )
-                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
@@ -863,12 +855,6 @@ class XODRParser:
                 prev_id      = center_line.id_
 
                 for ln in right_lane_nodes:
-                    if type_node is None:
-                        logging.warning(
-                            "Road %s has no <type> element; skipping right lane %s.",
-                            road_id, ln.attrib.get("id", "?"),
-                        )
-                        continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
@@ -896,7 +882,6 @@ class XODRParser:
         hdgs = np.arctan2(diff[:, 1], diff[:, 0]).tolist()
         hdgs.append(hdgs[-1])
         return hdgs
-
 
     def load_junction(self, junction_node: ET.Element) -> Junction:
         """Parse a ``<junction>`` element and return a Junction object.
@@ -931,7 +916,6 @@ class XODRParser:
             junction.add_connection(connection)
 
         return junction
-
 
     def parse(self, file_path: str) -> Map:
         """Parse an OpenDRIVE file and return a Tactics2D Map object.

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -918,7 +918,7 @@ class XODRParser:
         junction = Junction(id_=self._next_id())
 
         for conn_node in junction_node.findall("connection"):
-            connection = Junction.Connection(
+            connection = Junction(
                 id_=self._next_id(),
                 incoming_road=conn_node.attrib["incomingRoad"],
                 connecting_road=conn_node.attrib["connectingRoad"],

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -15,7 +15,7 @@ from shapely.affinity import affine_transform, rotate
 from shapely.geometry import LineString, Polygon
 from shapely.validation import make_valid
 
-from tactics2d.map.element import Area, Connection, Junction, Lane, Map, RoadLine
+from tactics2d.map.element import Area, Junction, Lane, Map, RoadLine
 from tactics2d.geometry import Circle
 from tactics2d.interpolator import ParamPoly3, Spiral
 
@@ -159,11 +159,15 @@ def _build_offset_polyline(
     collapsed = correction <= 0.0
     if np.any(collapsed):
         kappa_abs = np.abs(kappa)
-        safe_t = np.where(
-            kappa_abs > 1e-6,
-            0.99 / kappa_abs * np.sign(t_vals),
-            t_vals,
-        )
+        # np.where evaluates both branches before selecting; suppress the
+        # divide-by-zero that occurs on straight segments (kappa_abs == 0)
+        # before the kappa_abs > 1e-6 mask is applied.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            safe_t = np.where(
+                kappa_abs > 1e-6,
+                0.99 / kappa_abs * np.sign(t_vals),
+                t_vals,
+            )
         t_effective = np.where(collapsed, safe_t, t_vals)
     else:
         t_effective = t_vals
@@ -259,6 +263,14 @@ class XODRParser:
     # ------------------------------------------------------------------
 
     def _sample_line(self, node: ET.Element) -> list:
+        """Sample a straight-line geometry at 0.1 m intervals.
+
+        Args:
+            node (ET.Element): A ``<geometry>`` element whose child is ``<line>``.
+
+        Returns:
+            list: List of (x, y) world-coordinate tuples sampled along the line.
+        """
         x0  = float(node.attrib["x"])
         y0  = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
@@ -272,6 +284,14 @@ class XODRParser:
         return [(x0 + s * np.cos(hdg), y0 + s * np.sin(hdg)) for s in s_arr]
 
     def _sample_spiral(self, node: ET.Element) -> list:
+        """Sample a Euler spiral (clothoid) geometry using the Spiral integrator.
+
+        Args:
+            node (ET.Element): A ``<geometry>`` element whose child is ``<spiral>``.
+
+        Returns:
+            list: List of (x, y) world-coordinate tuples sampled along the spiral.
+        """
         x0  = float(node.attrib["x"])
         y0  = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
@@ -287,6 +307,17 @@ class XODRParser:
         return [(x, y) for x, y in pts]
 
     def _sample_arc(self, node: ET.Element) -> list:
+        """Sample a constant-curvature arc geometry at 0.1 m intervals.
+
+        Falls back to :meth:`_sample_line` when the curvature is negligibly
+        small (``|k| < 1e-9``).
+
+        Args:
+            node (ET.Element): A ``<geometry>`` element whose child is ``<arc>``.
+
+        Returns:
+            list: List of (x, y) world-coordinate tuples sampled along the arc.
+        """
         x0  = float(node.attrib["x"])
         y0  = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
@@ -318,6 +349,14 @@ class XODRParser:
         return [(x, y) for x, y in pts.tolist()]
 
     def _sample_poly3(self, node: ET.Element) -> list:
+        """Sample a cubic polynomial geometry (local u/v frame) at 0.1 m intervals.
+
+        Args:
+            node (ET.Element): A ``<geometry>`` element whose child is ``<poly3>``.
+
+        Returns:
+            list: List of (x, y) world-coordinate tuples sampled along the curve.
+        """
         x0  = float(node.attrib["x"])
         y0  = float(node.attrib["y"])
         hdg = float(node.attrib["hdg"])
@@ -335,6 +374,15 @@ class XODRParser:
         return list(zip(xs.tolist(), ys.tolist()))
 
     def _sample_param_poly3(self, node: ET.Element) -> list:
+        """Sample a parametric cubic polynomial geometry using the ParamPoly3 integrator.
+
+        Args:
+            node (ET.Element): A ``<geometry>`` element whose child is
+                ``<paramPoly3>``.
+
+        Returns:
+            list: List of (x, y) world-coordinate tuples sampled along the curve.
+        """
         x0      = float(node.attrib["x"])
         y0      = float(node.attrib["y"])
         hdg     = float(node.attrib["hdg"])
@@ -404,7 +452,23 @@ class XODRParser:
     def _make_roadline(self,
                        geometry: Union[list, LineString],
                        rm_node:  ET.Element) -> RoadLine:
-        """Construct a RoadLine from coordinate geometry and a <roadMark> node."""
+        """Construct a RoadLine from coordinate geometry and a ``<roadMark>`` node.
+
+        Maps OpenDRIVE road-mark type strings to Tactics2D line types and
+        subtypes, resolves colour aliases, and encodes the ``laneChange``
+        attribute as a boolean pair.
+
+        Args:
+            geometry (list or LineString): Coordinate sequence for the line,
+                either a list of (x, y) tuples or a Shapely LineString.
+            rm_node (ET.Element or None): The ``<roadMark>`` XML element.
+                When ``None`` a virtual (invisible) line is produced.
+
+        Returns:
+            RoadLine: A fully initialised RoadLine object with type, subtype,
+                colour, width, height, lane-change permission, and weight stored
+                in ``custom_tags``.
+        """
         rm = rm_node  # may be None
 
         rm_type = rm.attrib.get("type", "none") if rm is not None else "none"
@@ -482,6 +546,7 @@ class XODRParser:
         ref_normals:     np.ndarray,
         inner_t:         np.ndarray,
         inner_line_id:   int,
+        road_id:         str = "",
     ):
         """Build one lane and its outer boundary from the shared reference line.
 
@@ -505,6 +570,11 @@ class XODRParser:
                 accumulated lane widths. Shape is (N,).
             inner_line_id (int): The ``id_`` of the RoadLine representing the inner
                 boundary of this lane.
+            road_id (str): The OpenDRIVE road ``id`` attribute this lane belongs to.
+                Stored in ``custom_tags["xodr_road_id"]`` on the resulting Lane so
+                that format converters (e.g. SUMO, Lanelet2 exporters) can
+                unambiguously recover which road each lane originated from.
+                Defaults to empty string.
 
         Returns:
             tuple:
@@ -570,6 +640,7 @@ class XODRParser:
             speed_limit=speed_limit,
             speed_limit_unit=speed_limit_unit,
             location=location,
+            custom_tags={"xodr_road_id": road_id},
         )
 
         return lane, roadline, outer_t
@@ -668,6 +739,7 @@ class XODRParser:
         """
         lanes, roadlines, objects = [], [], []
         type_node = road_node.find("type")
+        road_id   = road_node.attrib.get("id", "")
 
         raw_pts: list = []
         raw_s:   list = []
@@ -790,11 +862,16 @@ class XODRParser:
 
                 for ln in left_lane_nodes:
                     if type_node is None:
+                        logging.warning(
+                            "Road %s has no <type> element; skipping left lane %s.",
+                            road_id, ln.attrib.get("id", "?"),
+                        )
                         continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
                         cumulative_t, prev_id,
+                        road_id=road_id,
                     )
                     lanes.append(lane)
                     roadlines.append(roadline)
@@ -811,11 +888,16 @@ class XODRParser:
 
                 for ln in right_lane_nodes:
                     if type_node is None:
+                        logging.warning(
+                            "Road %s has no <type> element; skipping right lane %s.",
+                            road_id, ln.attrib.get("id", "?"),
+                        )
                         continue
                     lane, roadline, cumulative_t = self._load_lane(
                         ln, type_node,
                         seg_ref_pts, seg_ref_s, seg_ref_n,
                         cumulative_t, prev_id,
+                        road_id=road_id,
                     )
                     lanes.append(lane)
                     roadlines.append(roadline)
@@ -844,10 +926,26 @@ class XODRParser:
     # ------------------------------------------------------------------
 
     def load_junction(self, junction_node: ET.Element) -> Junction:
+        """Parse a ``<junction>`` element and return a Junction object.
+
+        Args:
+            junction_node (ET.Element): The ``<junction>`` XML element to parse.
+
+        Returns:
+            Junction: A Junction populated with all ``<connection>`` child elements,
+                each carrying its lane-link list.
+
+        Example:
+            >>> parser = XODRParser()
+            >>> import xml.etree.ElementTree as ET
+            >>> tree = ET.parse("path/to/map.xodr")
+            >>> junction_node = tree.getroot().find("junction")
+            >>> junction = parser.load_junction(junction_node)
+        """
         junction = Junction(id_=self._next_id())
 
         for conn_node in junction_node.findall("connection"):
-            connection = Connection(
+            connection = Junction.Connection(
                 id_=self._next_id(),
                 incoming_road=conn_node.attrib["incomingRoad"],
                 connecting_road=conn_node.attrib["connectingRoad"],
@@ -874,6 +972,11 @@ class XODRParser:
         Returns:
             Map: A Tactics2D Map populated with lanes, roadlines, junctions,
                 and area objects parsed from the OpenDRIVE file.
+
+        Example:
+            >>> parser = XODRParser()
+            >>> map_ = parser.parse("path/to/map.xodr")
+            >>> print(len(map_.lanes))
         """
         xml_root = ET.parse(file_path).getroot()
 

--- a/tactics2d/renderer/matplotlib_config.py
+++ b/tactics2d/renderer/matplotlib_config.py
@@ -52,6 +52,18 @@ DEFAULT_COLOR = {
     "shared_walkway": "gray",
     "crosswalk": "dark-gray",
     "stairs": "gray",
+    # default color for junction class subtypes
+    # matches SUMO-GUI's default grey intersection fill
+    "junction": "dark-gray",
+    "priority": "dark-gray",
+    "traffic_light": "dark-gray",
+    "right_before_left": "dark-gray",
+    "unregulated": "dark-gray",
+    "dead_end": "dark-gray",
+    "rail_signal": "dark-gray",
+    "zipper": "dark-gray",
+    "rail_crossing": "dark-gray",
+    "allway_stop": "dark-gray",
     # default color for area class subtypes
     "area": "black",
     "hole": "white",
@@ -74,7 +86,6 @@ DEFAULT_COLOR = {
     "vehicle": "light-turquoise",
     "car": "light-turquoise",
     "truck": "light-turquoise",
-    "bus": "light-turquoise",
     # default color for cyclist class subtypes
     "motorcycle": "light-orange",
     "cyclist": "light-orange",
@@ -107,6 +118,19 @@ DEFAULT_ORDER = {
     "shared_walkway": 3,
     "crosswalk": 2,
     "stairs": 3,
+    # default zorder for junction class subtypes
+    # rendered below lanes (zorder 3) so lane polygons sit on top of the
+    # junction fill, keeping road markings visible at intersections
+    "junction": 2,
+    "priority": 2,
+    "traffic_light": 2,
+    "right_before_left": 2,
+    "unregulated": 2,
+    "dead_end": 2,
+    "rail_signal": 2,
+    "zipper": 2,
+    "rail_crossing": 2,
+    "allway_stop": 2,
     # default zorder for area class subtypes
     "area": 2,
     "hole": 3,
@@ -127,7 +151,6 @@ DEFAULT_ORDER = {
     "vehicle": 6,
     "car": 6,
     "truck": 6,
-    "bus": 6,
     "heading_arrow": 7,
     # default zorder for lidar point cloud
     "lidar_point_cloud": 8,

--- a/tactics2d/sensor/camera.py
+++ b/tactics2d/sensor/camera.py
@@ -8,9 +8,9 @@ import time
 from typing import Any, Dict, List, Set, Tuple, Union
 
 import numpy as np
-from shapely.geometry import Point
+from shapely.geometry import Point, Polygon
 
-from tactics2d.map.element import Area, Lane, Map, RoadLine
+from tactics2d.map.element import Area, Junction, Lane, Map, RoadLine
 from tactics2d.participant.element import Cyclist, Obstacle, Pedestrian, Vehicle
 
 from .sensor_base import SensorBase
@@ -57,7 +57,7 @@ class BEVCamera(SensorBase):
         """Get the type string for a map or participant element.
 
         Args:
-            element: Map element (Area, Lane, RoadLine) or participant element.
+            element: Map element (Area, Junction, Lane, RoadLine) or participant element.
 
         Returns:
             String type identifier for the element.
@@ -66,6 +66,11 @@ class BEVCamera(SensorBase):
             return element.subtype
         elif hasattr(element, "type_") and element.type_:
             return element.type_
+        elif isinstance(element, Junction):
+            # Use the SUMO junction type stored in custom_tags when available,
+            # otherwise fall back to the generic "junction" key so that
+            # matplotlib_config.DEFAULT_COLOR["junction"] is resolved.
+            return element.custom_tags.get("type") or "junction"
         elif isinstance(element, Area):
             return "area"
         elif isinstance(element, Lane):
@@ -84,6 +89,10 @@ class BEVCamera(SensorBase):
     def _get_map_elements(self, prev_road_id_set: Set[int]) -> Tuple[Dict, Set[int]]:
         """Get map elements within perception range for rendering.
 
+        Processes junctions, areas, lanes, and roadlines in z-order (lowest first)
+        so that junction fill polygons are drawn beneath lane polygons and road
+        markings, matching SUMO-GUI's default visual style.
+
         Args:
             prev_road_id_set: Set of road IDs from previous frame.
 
@@ -91,11 +100,38 @@ class BEVCamera(SensorBase):
             Tuple of (map_data, road_id_set) where map_data contains road elements
             to remove and create, and road_id_set is the set of road IDs in current frame.
         """
-        road_id_list = []
+        road_id_list    = []
         road_element_list = []
         white = "white"
 
-        # Process areas (obstacles, etc.)
+        for junction in self._map.junctions.values():
+            shape_pts = junction.custom_tags.get("shape", [])
+            if len(shape_pts) < 3:
+                continue
+
+            try:
+                junction_polygon = Polygon(shape_pts)
+            except Exception:
+                continue
+
+            if not self._in_perception_range(junction_polygon):
+                continue
+
+            junc_type  = self._get_type(junction)
+            element_id = int(2e6 + int(junction.id_))
+
+            road_element_list.append(
+                {
+                    "id":         element_id,
+                    "shape":      "polygon",
+                    "geometry":   list(junction_polygon.exterior.coords),
+                    "color":      junc_type,
+                    "type":       junc_type,
+                    "line_width": 0,
+                }
+            )
+            road_id_list.append(element_id)
+
         for area in self._map.areas.values():
             if not self._in_perception_range(area.geometry):
                 continue
@@ -104,11 +140,11 @@ class BEVCamera(SensorBase):
 
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(area.id_)),
-                    "shape": "polygon",
-                    "geometry": list(area.geometry.exterior.coords),
-                    "color": area.color,
-                    "type": self._get_type(area),
+                    "id":         int(1e6 + int(area.id_)),
+                    "shape":      "polygon",
+                    "geometry":   list(area.geometry.exterior.coords),
+                    "color":      area.color,
+                    "type":       self._get_type(area),
                     "line_width": 0,
                 }
             )
@@ -117,34 +153,32 @@ class BEVCamera(SensorBase):
             for i, interior in enumerate(interiors):
                 road_element_list.append(
                     {
-                        "id": int(1e6 + int(area.id_) + i * 1e5),
-                        "shape": "polygon",
-                        "geometry": list(interior.coords),
-                        "color": white,
-                        "type": "hole",
+                        "id":         int(1e6 + int(area.id_) + i * 1e5),
+                        "shape":      "polygon",
+                        "geometry":   list(interior.coords),
+                        "color":      white,
+                        "type":       "hole",
                         "line_width": 0,
                     }
                 )
                 road_id_list.append(int(1e6 + int(area.id_) + i * 1e5))
 
-        # Process lanes
         for lane in self._map.lanes.values():
             if not self._in_perception_range(lane.geometry):
                 continue
 
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(lane.id_)),
-                    "shape": "polygon",
-                    "geometry": list(lane.geometry.coords),
-                    "color": lane.color,
-                    "type": self._get_type(lane),
+                    "id":         int(1e6 + int(lane.id_)),
+                    "shape":      "polygon",
+                    "geometry":   list(lane.geometry.coords),
+                    "color":      lane.color,
+                    "type":       self._get_type(lane),
                     "line_width": 0,
                 }
             )
             road_id_list.append(int(1e6 + int(lane.id_)))
 
-        # Process roadlines (skip virtual lines)
         for roadline in self._map.roadlines.values():
             if roadline.type_ == "virtual" or not self._in_perception_range(roadline.geometry):
                 continue
@@ -155,38 +189,32 @@ class BEVCamera(SensorBase):
             elif "thick" in roadline.type_:
                 line_width = 2
 
-            line_color = roadline.color
-            if roadline.type_ == "virtual":
-                line_color = None
-            else:
-                line_color = white if roadline.color is None else roadline.color
+            line_color = white if roadline.color is None else roadline.color
 
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(roadline.id_)),
-                    "shape": "line",
-                    "geometry": list(roadline.geometry.coords),
-                    "color": line_color,
-                    "type": self._get_type(roadline),
+                    "id":         int(1e6 + int(roadline.id_)),
+                    "shape":      "line",
+                    "geometry":   list(roadline.geometry.coords),
+                    "color":      line_color,
+                    "type":       self._get_type(roadline),
                     "line_style": roadline.subtype if roadline.subtype is not None else "solid",
                     "line_width": line_width,
                 }
             )
             road_id_list.append(int(1e6 + int(roadline.id_)))
 
-        # Create the map geometry message flow
-        road_id_set = set(road_id_list)
+        road_id_set       = set(road_id_list)
         road_id_to_create = road_id_set - prev_road_id_set
         road_id_to_remove = prev_road_id_set - road_id_set
 
-        road_element_to_create = []
-        for road_element in road_element_list:
-            if road_element["id"] in road_id_to_create:
-                road_element_to_create.append(road_element)
+        road_element_to_create = [
+            el for el in road_element_list if el["id"] in road_id_to_create
+        ]
 
         map_data = {
             "road_id_to_remove": list(road_id_to_remove),
-            "road_elements": road_element_to_create,
+            "road_elements":     road_element_to_create,
         }
 
         return map_data, road_id_set
@@ -212,42 +240,42 @@ class BEVCamera(SensorBase):
             participant IDs in current frame.
         """
         participant_id_list = []
-        participant_list = []
-        black = "black"
+        participant_list    = []
+        black               = "black"
 
-        # Process each participant (vehicle, cyclist, pedestrian, obstacle)
         for participant_id in participant_ids:
-            participant = participants[participant_id]
+            participant          = participants[participant_id]
             participant_geometry = participant.get_pose(frame)
+
             if isinstance(participant, Pedestrian):
-                participant_radius = participant_geometry[1]
-                participant_radius = participant_radius if participant_radius > 0 else 0
+                participant_radius   = participant_geometry[1]
+                participant_radius   = participant_radius if participant_radius > 0 else 0
                 participant_geometry = Point(participant_geometry[0])
 
             if not self._in_perception_range(participant_geometry):
                 continue
 
             if isinstance(participant, Vehicle) or isinstance(participant, Cyclist):
-                points = np.array(participant.geometry.coords)
+                points   = np.array(participant.geometry.coords)
                 triangle = [
                     ((points[0] + points[1]) / 2).tolist(),
                     ((points[1] + points[2]) / 2).tolist(),
                     ((points[3] + points[0]) / 2).tolist(),
                 ]
-                state = participant.trajectory.get_state(frame)
+                state    = participant.trajectory.get_state(frame)
                 position = list(state.location)
-                heading = state.heading
-                id_ = abs(int(participant.id_))
+                heading  = state.heading
+                id_      = abs(int(participant.id_))
 
                 participant_list.append(
                     {
-                        "id": id_,
-                        "shape": "polygon",
+                        "id":       id_,
+                        "shape":    "polygon",
                         "geometry": points.tolist(),
                         "position": position,
                         "rotation": heading,
-                        "color": participant.color,
-                        "type": self._get_type(participant),
+                        "color":    participant.color,
+                        "type":     self._get_type(participant),
                         "line_width": 1,
                     }
                 )
@@ -255,13 +283,13 @@ class BEVCamera(SensorBase):
 
                 participant_list.append(
                     {
-                        "id": id_ + 0.5,
-                        "shape": "polygon",
+                        "id":       id_ + 0.5,
+                        "shape":    "polygon",
                         "geometry": triangle,
                         "position": position,
                         "rotation": heading,
-                        "color": black,
-                        "type": "heading_arrow",
+                        "color":    black,
+                        "type":     "heading_arrow",
                         "line_width": 0,
                     }
                 )
@@ -271,12 +299,12 @@ class BEVCamera(SensorBase):
                 id_ = abs(int(participant.id_))
                 participant_list.append(
                     {
-                        "id": id_,
-                        "shape": "circle",
+                        "id":       id_,
+                        "shape":    "circle",
                         "position": [participant_geometry.x, participant_geometry.y],
-                        "radius": participant_radius,
-                        "color": participant.color,
-                        "type": self._get_type(participant),
+                        "radius":   participant_radius,
+                        "color":    participant.color,
+                        "type":     self._get_type(participant),
                         "line_width": 1,
                     }
                 )
@@ -285,15 +313,14 @@ class BEVCamera(SensorBase):
             elif isinstance(participant, Obstacle):
                 pass
 
-        # Create the participant geometry message flow
-        participant_id_set = set(participant_id_list)
-        participant_id_to_create = participant_id_set - prev_participant_id_set
-        participant_id_to_remove = prev_participant_id_set - participant_id_set
+        participant_id_set        = set(participant_id_list)
+        participant_id_to_create  = participant_id_set - prev_participant_id_set
+        participant_id_to_remove  = prev_participant_id_set - participant_id_set
 
         participant_data = {
             "participant_id_to_create": list(participant_id_to_create),
             "participant_id_to_remove": list(participant_id_to_remove),
-            "participants": participant_list,
+            "participants":             participant_list,
         }
 
         return participant_data, participant_id_set
@@ -308,7 +335,7 @@ class BEVCamera(SensorBase):
         position: Point = None,
         heading: float = None,
     ) -> Tuple[Dict, Set, Set]:
-        """This function is used to update the camera's position and obtain the geometry data under specific rendering paradigm.
+        """Update the camera's position and return geometry data for rendering.
 
         Args:
             frame (int): The frame of the observation.
@@ -328,29 +355,26 @@ class BEVCamera(SensorBase):
         """
         self._set_position_heading(position, heading)
 
-        # Use base class method to setup default parameters
         participant_ids, prev_road_id_set, prev_participant_id_set = self._setup_update_parameters(
             participant_ids, prev_road_id_set, prev_participant_id_set
         )
 
-        map_data, road_id_set = self._get_map_elements(prev_road_id_set)
-        participant_data, participant_id_set = self._get_participants(
+        map_data,         road_id_set         = self._get_map_elements(prev_road_id_set)
+        participant_data, participant_id_set   = self._get_participants(
             frame, participants, participant_ids, prev_participant_id_set
         )
 
-        # Unified geometry data format compatible with renderer
         geometry_data = {
-            "frame": frame,
-            "map_data": map_data,
+            "frame":            frame,
+            "map_data":         map_data,
             "participant_data": participant_data,
-            # Additional sensor metadata for consistency with lidar
             "metadata": {
-                "timestamp": time.time(),
+                "timestamp":        time.time(),
                 "perception_range": self._perception_range,
-                "sensor_type": "camera",
-                "sensor_id": self.id_,
-                "sensor_position": self._position,
-                "sensor_yaw": self._heading,
+                "sensor_type":      "camera",
+                "sensor_id":        self.id_,
+                "sensor_position":  self._position,
+                "sensor_yaw":       self._heading,
             },
         }
 

--- a/tactics2d/sensor/camera.py
+++ b/tactics2d/sensor/camera.py
@@ -100,10 +100,11 @@ class BEVCamera(SensorBase):
             Tuple of (map_data, road_id_set) where map_data contains road elements
             to remove and create, and road_id_set is the set of road IDs in current frame.
         """
-        road_id_list    = []
+        road_id_list = []
         road_element_list = []
         white = "white"
 
+        # Process junctions (z-order 2, beneath lanes)
         for junction in self._map.junctions.values():
             shape_pts = junction.custom_tags.get("shape", [])
             if len(shape_pts) < 3:
@@ -117,21 +118,22 @@ class BEVCamera(SensorBase):
             if not self._in_perception_range(junction_polygon):
                 continue
 
-            junc_type  = self._get_type(junction)
+            junc_type = self._get_type(junction)
             element_id = int(2e6 + int(junction.id_))
 
             road_element_list.append(
                 {
-                    "id":         element_id,
-                    "shape":      "polygon",
-                    "geometry":   list(junction_polygon.exterior.coords),
-                    "color":      junc_type,
-                    "type":       junc_type,
+                    "id": element_id,
+                    "shape": "polygon",
+                    "geometry": list(junction_polygon.exterior.coords),
+                    "color": junc_type,
+                    "type": junc_type,
                     "line_width": 0,
                 }
             )
             road_id_list.append(element_id)
 
+        # Process areas (obstacles, etc.)
         for area in self._map.areas.values():
             if not self._in_perception_range(area.geometry):
                 continue
@@ -140,11 +142,11 @@ class BEVCamera(SensorBase):
 
             road_element_list.append(
                 {
-                    "id":         int(1e6 + int(area.id_)),
-                    "shape":      "polygon",
-                    "geometry":   list(area.geometry.exterior.coords),
-                    "color":      area.color,
-                    "type":       self._get_type(area),
+                    "id": int(1e6 + int(area.id_)),
+                    "shape": "polygon",
+                    "geometry": list(area.geometry.exterior.coords),
+                    "color": area.color,
+                    "type": self._get_type(area),
                     "line_width": 0,
                 }
             )
@@ -153,32 +155,34 @@ class BEVCamera(SensorBase):
             for i, interior in enumerate(interiors):
                 road_element_list.append(
                     {
-                        "id":         int(1e6 + int(area.id_) + i * 1e5),
-                        "shape":      "polygon",
-                        "geometry":   list(interior.coords),
-                        "color":      white,
-                        "type":       "hole",
+                        "id": int(1e6 + int(area.id_) + i * 1e5),
+                        "shape": "polygon",
+                        "geometry": list(interior.coords),
+                        "color": white,
+                        "type": "hole",
                         "line_width": 0,
                     }
                 )
                 road_id_list.append(int(1e6 + int(area.id_) + i * 1e5))
 
+        # Process lanes
         for lane in self._map.lanes.values():
             if not self._in_perception_range(lane.geometry):
                 continue
 
             road_element_list.append(
                 {
-                    "id":         int(1e6 + int(lane.id_)),
-                    "shape":      "polygon",
-                    "geometry":   list(lane.geometry.coords),
-                    "color":      lane.color,
-                    "type":       self._get_type(lane),
+                    "id": int(1e6 + int(lane.id_)),
+                    "shape": "polygon",
+                    "geometry": list(lane.geometry.coords),
+                    "color": lane.color,
+                    "type": self._get_type(lane),
                     "line_width": 0,
                 }
             )
             road_id_list.append(int(1e6 + int(lane.id_)))
 
+        # Process roadlines (skip virtual lines)
         for roadline in self._map.roadlines.values():
             if roadline.type_ == "virtual" or not self._in_perception_range(roadline.geometry):
                 continue
@@ -193,28 +197,29 @@ class BEVCamera(SensorBase):
 
             road_element_list.append(
                 {
-                    "id":         int(1e6 + int(roadline.id_)),
-                    "shape":      "line",
-                    "geometry":   list(roadline.geometry.coords),
-                    "color":      line_color,
-                    "type":       self._get_type(roadline),
+                    "id": int(1e6 + int(roadline.id_)),
+                    "shape": "line",
+                    "geometry": list(roadline.geometry.coords),
+                    "color": line_color,
+                    "type": self._get_type(roadline),
                     "line_style": roadline.subtype if roadline.subtype is not None else "solid",
                     "line_width": line_width,
                 }
             )
             road_id_list.append(int(1e6 + int(roadline.id_)))
 
-        road_id_set       = set(road_id_list)
+        road_id_set = set(road_id_list)
         road_id_to_create = road_id_set - prev_road_id_set
         road_id_to_remove = prev_road_id_set - road_id_set
 
-        road_element_to_create = [
-            el for el in road_element_list if el["id"] in road_id_to_create
-        ]
+        road_element_to_create = []
+        for road_element in road_element_list:
+            if road_element["id"] in road_id_to_create:
+                road_element_to_create.append(road_element)
 
         map_data = {
             "road_id_to_remove": list(road_id_to_remove),
-            "road_elements":     road_element_to_create,
+            "road_elements": road_element_to_create,
         }
 
         return map_data, road_id_set
@@ -240,42 +245,42 @@ class BEVCamera(SensorBase):
             participant IDs in current frame.
         """
         participant_id_list = []
-        participant_list    = []
-        black               = "black"
+        participant_list = []
+        black = "black"
 
         for participant_id in participant_ids:
-            participant          = participants[participant_id]
+            participant = participants[participant_id]
             participant_geometry = participant.get_pose(frame)
 
             if isinstance(participant, Pedestrian):
-                participant_radius   = participant_geometry[1]
-                participant_radius   = participant_radius if participant_radius > 0 else 0
+                participant_radius = participant_geometry[1]
+                participant_radius = participant_radius if participant_radius > 0 else 0
                 participant_geometry = Point(participant_geometry[0])
 
             if not self._in_perception_range(participant_geometry):
                 continue
 
             if isinstance(participant, Vehicle) or isinstance(participant, Cyclist):
-                points   = np.array(participant.geometry.coords)
+                points = np.array(participant.geometry.coords)
                 triangle = [
                     ((points[0] + points[1]) / 2).tolist(),
                     ((points[1] + points[2]) / 2).tolist(),
                     ((points[3] + points[0]) / 2).tolist(),
                 ]
-                state    = participant.trajectory.get_state(frame)
+                state = participant.trajectory.get_state(frame)
                 position = list(state.location)
-                heading  = state.heading
-                id_      = abs(int(participant.id_))
+                heading = state.heading
+                id_ = abs(int(participant.id_))
 
                 participant_list.append(
                     {
-                        "id":       id_,
-                        "shape":    "polygon",
+                        "id": id_,
+                        "shape": "polygon",
                         "geometry": points.tolist(),
                         "position": position,
                         "rotation": heading,
-                        "color":    participant.color,
-                        "type":     self._get_type(participant),
+                        "color": participant.color,
+                        "type": self._get_type(participant),
                         "line_width": 1,
                     }
                 )
@@ -283,13 +288,13 @@ class BEVCamera(SensorBase):
 
                 participant_list.append(
                     {
-                        "id":       id_ + 0.5,
-                        "shape":    "polygon",
+                        "id": id_ + 0.5,
+                        "shape": "polygon",
                         "geometry": triangle,
                         "position": position,
                         "rotation": heading,
-                        "color":    black,
-                        "type":     "heading_arrow",
+                        "color": black,
+                        "type": "heading_arrow",
                         "line_width": 0,
                     }
                 )
@@ -299,12 +304,12 @@ class BEVCamera(SensorBase):
                 id_ = abs(int(participant.id_))
                 participant_list.append(
                     {
-                        "id":       id_,
-                        "shape":    "circle",
+                        "id": id_,
+                        "shape": "circle",
                         "position": [participant_geometry.x, participant_geometry.y],
-                        "radius":   participant_radius,
-                        "color":    participant.color,
-                        "type":     self._get_type(participant),
+                        "radius": participant_radius,
+                        "color": participant.color,
+                        "type": self._get_type(participant),
                         "line_width": 1,
                     }
                 )
@@ -313,14 +318,14 @@ class BEVCamera(SensorBase):
             elif isinstance(participant, Obstacle):
                 pass
 
-        participant_id_set        = set(participant_id_list)
-        participant_id_to_create  = participant_id_set - prev_participant_id_set
-        participant_id_to_remove  = prev_participant_id_set - participant_id_set
+        participant_id_set = set(participant_id_list)
+        participant_id_to_create = participant_id_set - prev_participant_id_set
+        participant_id_to_remove = prev_participant_id_set - participant_id_set
 
         participant_data = {
             "participant_id_to_create": list(participant_id_to_create),
             "participant_id_to_remove": list(participant_id_to_remove),
-            "participants":             participant_list,
+            "participants": participant_list,
         }
 
         return participant_data, participant_id_set
@@ -335,7 +340,7 @@ class BEVCamera(SensorBase):
         position: Point = None,
         heading: float = None,
     ) -> Tuple[Dict, Set, Set]:
-        """Update the camera's position and return geometry data for rendering.
+        """This function is used to update the camera's position and obtain the geometry data under specific rendering paradigm.
 
         Args:
             frame (int): The frame of the observation.
@@ -359,22 +364,22 @@ class BEVCamera(SensorBase):
             participant_ids, prev_road_id_set, prev_participant_id_set
         )
 
-        map_data,         road_id_set         = self._get_map_elements(prev_road_id_set)
-        participant_data, participant_id_set   = self._get_participants(
+        map_data, road_id_set = self._get_map_elements(prev_road_id_set)
+        participant_data, participant_id_set = self._get_participants(
             frame, participants, participant_ids, prev_participant_id_set
         )
 
         geometry_data = {
-            "frame":            frame,
-            "map_data":         map_data,
+            "frame": frame,
+            "map_data": map_data,
             "participant_data": participant_data,
             "metadata": {
-                "timestamp":        time.time(),
+                "timestamp": time.time(),
                 "perception_range": self._perception_range,
-                "sensor_type":      "camera",
-                "sensor_id":        self.id_,
-                "sensor_position":  self._position,
-                "sensor_yaw":       self._heading,
+                "sensor_type": "camera",
+                "sensor_id": self.id_,
+                "sensor_position": self._position,
+                "sensor_yaw": self._heading,
             },
         }
 

--- a/tests/cases/NetXMLSamples/lefthand.net.xml
+++ b/tests/cases/NetXMLSamples/lefthand.net.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Wed Apr  1 14:18:54 2020 by Eclipse SUMO netconvert Version v1_5_0+1059-24fef65bc7
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
+
+    <input>
+        <node-files value="input_plain2.nod.xml"/>
+        <edge-files value="input_plain2.edg.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <output-file value="lefthand.net.xml"/>
+    </output>
+
+    <processing>
+        <lefthand value="true"/>
+    </processing>
+
+    <report>
+        <aggregate-warnings value="5"/>
+    </report>
+
+</configuration>
+-->
+
+<net version="1.6" junctionCornerDetail="5" lefthand="true" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+
+    <location netOffset="100.00,100.00" convBoundary="0.00,-0.00,200.00,200.00" origBoundary="-10000000000.00,-10000000000.00,10000000000.00,10000000000.00" projParameter="!"/>
+
+    <edge id=":C_0" function="internal">
+        <lane id=":C_0_0" index="0" speed="6.51" length="9.03" shape="95.20,89.60 94.85,92.05 93.80,93.80 92.05,94.85 89.60,95.20"/>
+    </edge>
+    <edge id=":C_1" function="internal">
+        <lane id=":C_1_0" index="0" speed="13.89" length="20.80" shape="95.20,89.60 95.20,110.40"/>
+        <lane id=":C_1_1" index="1" speed="13.89" length="20.80" shape="98.40,89.60 98.40,110.40"/>
+    </edge>
+    <edge id=":C_3" function="internal">
+        <lane id=":C_3_0" index="0" speed="9.26" length="6.96" shape="98.40,89.60 99.15,94.85 100.00,96.27"/>
+    </edge>
+    <edge id=":C_4" function="internal">
+        <lane id=":C_4_0" index="0" speed="3.65" length="2.34" shape="98.40,89.60 99.20,90.80 100.00,91.20"/>
+    </edge>
+    <edge id=":C_20" function="internal">
+        <lane id=":C_20_0" index="0" speed="9.26" length="12.40" shape="100.00,96.27 101.40,98.60 105.15,100.85 110.40,101.60"/>
+    </edge>
+    <edge id=":C_21" function="internal">
+        <lane id=":C_21_0" index="0" speed="3.65" length="2.34" shape="100.00,91.20 100.80,90.80 101.60,89.60"/>
+    </edge>
+    <edge id=":C_5" function="internal">
+        <lane id=":C_5_0" index="0" speed="6.51" length="9.03" shape="110.40,95.20 107.95,94.85 106.20,93.80 105.15,92.05 104.80,89.60"/>
+    </edge>
+    <edge id=":C_6" function="internal">
+        <lane id=":C_6_0" index="0" speed="13.89" length="20.80" shape="110.40,95.20 89.60,95.20"/>
+        <lane id=":C_6_1" index="1" speed="13.89" length="20.80" shape="110.40,98.40 89.60,98.40"/>
+    </edge>
+    <edge id=":C_8" function="internal">
+        <lane id=":C_8_0" index="0" speed="9.26" length="6.96" shape="110.40,98.40 105.15,99.15 103.73,100.00"/>
+    </edge>
+    <edge id=":C_9" function="internal">
+        <lane id=":C_9_0" index="0" speed="3.65" length="2.34" shape="110.40,98.40 109.20,99.20 108.80,100.00"/>
+    </edge>
+    <edge id=":C_22" function="internal">
+        <lane id=":C_22_0" index="0" speed="9.26" length="12.40" shape="103.73,100.00 101.40,101.40 99.15,105.15 98.40,110.40"/>
+    </edge>
+    <edge id=":C_23" function="internal">
+        <lane id=":C_23_0" index="0" speed="3.65" length="2.34" shape="108.80,100.00 109.20,100.80 110.40,101.60"/>
+    </edge>
+    <edge id=":C_10" function="internal">
+        <lane id=":C_10_0" index="0" speed="6.51" length="9.03" shape="104.80,110.40 105.15,107.95 106.20,106.20 107.95,105.15 110.40,104.80"/>
+    </edge>
+    <edge id=":C_11" function="internal">
+        <lane id=":C_11_0" index="0" speed="13.89" length="20.80" shape="104.80,110.40 104.80,89.60"/>
+        <lane id=":C_11_1" index="1" speed="13.89" length="20.80" shape="101.60,110.40 101.60,89.60"/>
+    </edge>
+    <edge id=":C_13" function="internal">
+        <lane id=":C_13_0" index="0" speed="9.26" length="6.96" shape="101.60,110.40 100.85,105.15 100.00,103.73"/>
+    </edge>
+    <edge id=":C_14" function="internal">
+        <lane id=":C_14_0" index="0" speed="3.65" length="2.34" shape="101.60,110.40 100.80,109.20 100.00,108.80"/>
+    </edge>
+    <edge id=":C_24" function="internal">
+        <lane id=":C_24_0" index="0" speed="9.26" length="12.40" shape="100.00,103.73 98.60,101.40 94.85,99.15 89.60,98.40"/>
+    </edge>
+    <edge id=":C_25" function="internal">
+        <lane id=":C_25_0" index="0" speed="3.65" length="2.34" shape="100.00,108.80 99.20,109.20 98.40,110.40"/>
+    </edge>
+    <edge id=":C_15" function="internal">
+        <lane id=":C_15_0" index="0" speed="6.51" length="9.03" shape="89.60,104.80 92.05,105.15 93.80,106.20 94.85,107.95 95.20,110.40"/>
+    </edge>
+    <edge id=":C_16" function="internal">
+        <lane id=":C_16_0" index="0" speed="13.89" length="20.80" shape="89.60,104.80 110.40,104.80"/>
+        <lane id=":C_16_1" index="1" speed="13.89" length="20.80" shape="89.60,101.60 110.40,101.60"/>
+    </edge>
+    <edge id=":C_18" function="internal">
+        <lane id=":C_18_0" index="0" speed="9.26" length="6.96" shape="89.60,101.60 94.85,100.85 96.27,100.00"/>
+    </edge>
+    <edge id=":C_19" function="internal">
+        <lane id=":C_19_0" index="0" speed="3.65" length="2.34" shape="89.60,101.60 90.80,100.80 91.20,100.00"/>
+    </edge>
+    <edge id=":C_26" function="internal">
+        <lane id=":C_26_0" index="0" speed="9.26" length="12.40" shape="96.27,100.00 98.60,98.60 100.85,94.85 101.60,89.60"/>
+    </edge>
+    <edge id=":C_27" function="internal">
+        <lane id=":C_27_0" index="0" speed="3.65" length="2.34" shape="91.20,100.00 90.80,99.20 89.60,98.40"/>
+    </edge>
+    <edge id=":E_0" function="internal">
+        <lane id=":E_0_0" index="0" speed="3.65" length="4.67" shape="200.00,101.60 201.20,100.80 201.60,100.00 201.20,99.20 200.00,98.40"/>
+    </edge>
+    <edge id=":N_0" function="internal">
+        <lane id=":N_0_0" index="0" speed="3.65" length="4.67" shape="98.40,200.00 99.20,201.20 100.00,201.60 100.80,201.20 101.60,200.00"/>
+    </edge>
+    <edge id=":S_0" function="internal">
+        <lane id=":S_0_0" index="0" speed="3.65" length="4.67" shape="101.60,-0.00 100.80,-1.20 100.00,-1.60 99.20,-1.20 98.40,-0.00"/>
+    </edge>
+    <edge id=":W_0" function="internal">
+        <lane id=":W_0_0" index="0" speed="3.65" length="4.67" shape="0.00,98.40 -1.20,99.20 -1.60,100.00 -1.20,100.80 0.00,101.60"/>
+    </edge>
+
+    <edge id="CE" from="C" to="E" priority="2">
+        <lane id="CE_0" index="0" speed="13.89" length="89.60" shape="110.40,104.80 200.00,104.80"/>
+        <lane id="CE_1" index="1" speed="13.89" length="89.60" shape="110.40,101.60 200.00,101.60"/>
+    </edge>
+    <edge id="CN" from="C" to="N" priority="2">
+        <lane id="CN_0" index="0" speed="13.89" length="89.60" shape="95.20,110.40 95.20,200.00"/>
+        <lane id="CN_1" index="1" speed="13.89" length="89.60" shape="98.40,110.40 98.40,200.00"/>
+    </edge>
+    <edge id="CS" from="C" to="S" priority="2">
+        <lane id="CS_0" index="0" speed="13.89" length="89.60" shape="104.80,89.60 104.80,-0.00"/>
+        <lane id="CS_1" index="1" speed="13.89" length="89.60" shape="101.60,89.60 101.60,-0.00"/>
+    </edge>
+    <edge id="CW" from="C" to="W" priority="2">
+        <lane id="CW_0" index="0" speed="13.89" length="89.60" shape="89.60,95.20 0.00,95.20"/>
+        <lane id="CW_1" index="1" speed="13.89" length="89.60" shape="89.60,98.40 0.00,98.40"/>
+    </edge>
+    <edge id="EC" from="E" to="C" priority="2">
+        <lane id="EC_0" index="0" speed="13.89" length="89.60" shape="200.00,95.20 110.40,95.20"/>
+        <lane id="EC_1" index="1" speed="13.89" length="89.60" shape="200.00,98.40 110.40,98.40"/>
+    </edge>
+    <edge id="NC" from="N" to="C" priority="2">
+        <lane id="NC_0" index="0" speed="13.89" length="89.60" shape="104.80,200.00 104.80,110.40"/>
+        <lane id="NC_1" index="1" speed="13.89" length="89.60" shape="101.60,200.00 101.60,110.40"/>
+    </edge>
+    <edge id="SC" from="S" to="C" priority="2">
+        <lane id="SC_0" index="0" speed="13.89" length="89.60" shape="95.20,-0.00 95.20,89.60"/>
+        <lane id="SC_1" index="1" speed="13.89" length="89.60" shape="98.40,-0.00 98.40,89.60"/>
+    </edge>
+    <edge id="WC" from="W" to="C" priority="2">
+        <lane id="WC_0" index="0" speed="13.89" length="89.60" shape="0.00,104.80 89.60,104.80"/>
+        <lane id="WC_1" index="1" speed="13.89" length="89.60" shape="0.00,101.60 89.60,101.60"/>
+    </edge>
+
+    <tlLogic id="C" type="static" programID="0" offset="0">
+        <phase duration="42" state="GGGggrrrrrGGGggrrrrr"/>
+        <phase duration="3"  state="yyyyyrrrrryyyyyrrrrr"/>
+        <phase duration="42" state="rrrrrGGGggrrrrrGGGgg"/>
+        <phase duration="3"  state="rrrrryyyyyrrrrryyyyy"/>
+    </tlLogic>
+
+    <junction id="C" type="traffic_light" x="100.00" y="100.00" incLanes="SC_0 SC_1 EC_0 EC_1 NC_0 NC_1 WC_0 WC_1" intLanes=":C_0_0 :C_1_0 :C_1_1 :C_20_0 :C_21_0 :C_5_0 :C_6_0 :C_6_1 :C_22_0 :C_23_0 :C_10_0 :C_11_0 :C_11_1 :C_24_0 :C_25_0 :C_15_0 :C_16_0 :C_16_1 :C_26_0 :C_27_0" shape="93.60,89.60 106.40,89.60 106.84,91.82 107.40,92.60 108.18,93.16 109.18,93.49 110.40,93.60 110.40,106.40 108.18,106.84 107.40,107.40 106.84,108.18 106.51,109.18 106.40,110.40 93.60,110.40 93.16,108.18 92.60,107.40 91.82,106.84 90.82,106.51 89.60,106.40 89.60,93.60 91.82,93.16 92.60,92.60 93.16,91.82 93.49,90.82">
+        <request index="0"  response="00000000000000000000" foes="00000000000011000000" cont="0"/>
+        <request index="1"  response="01000000000100000000" foes="01111110000111000000" cont="0"/>
+        <request index="2"  response="01000000000100000000" foes="01111110000111000000" cont="0"/>
+        <request index="3"  response="01000001100100000000" foes="01110001101111000000" cont="1"/>
+        <request index="4"  response="01000001100000000000" foes="01000001100000000000" cont="1"/>
+        <request index="5"  response="00000001100000000000" foes="00000001100000000000" cont="0"/>
+        <request index="6"  response="00000011100000001111" foes="11000011100000001111" cont="0"/>
+        <request index="7"  response="00000011100000001111" foes="11000011100000001111" cont="0"/>
+        <request index="8"  response="00110011100000001110" foes="00110111100000001110" cont="1"/>
+        <request index="9"  response="00110000000000001000" foes="00110000000000001000" cont="1"/>
+        <request index="10" response="00000000000000000000" foes="00110000000000000000" cont="0"/>
+        <request index="11" response="01000000000100000000" foes="01110000000111111000" cont="0"/>
+        <request index="12" response="01000000000100000000" foes="01110000000111111000" cont="0"/>
+        <request index="13" response="01000000000100000110" foes="11110000000111000110" cont="1"/>
+        <request index="14" response="00000000000100000110" foes="00000000000100000110" cont="1"/>
+        <request index="15" response="00000000000000000110" foes="00000000000000000110" cont="0"/>
+        <request index="16" response="00000011110000001110" foes="00000011111100001110" cont="0"/>
+        <request index="17" response="00000011110000001110" foes="00000011111100001110" cont="0"/>
+        <request index="18" response="00000011100011001110" foes="00000011100011011110" cont="1"/>
+        <request index="19" response="00000010000011000000" foes="00000010000011000000" cont="1"/>
+    </junction>
+    <junction id="E" type="priority" x="200.00" y="100.00" incLanes="CE_0 CE_1" intLanes=":E_0_0" shape="200.00,100.00 200.00,106.40 200.00,100.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="N" type="priority" x="100.00" y="200.00" incLanes="CN_0 CN_1" intLanes=":N_0_0" shape="100.00,200.00 93.60,200.00 100.00,200.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="S" type="priority" x="100.00" y="-0.00" incLanes="CS_0 CS_1" intLanes=":S_0_0" shape="100.00,-0.00 106.40,-0.00 100.00,-0.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="W" type="priority" x="0.00" y="100.00" incLanes="CW_0 CW_1" intLanes=":W_0_0" shape="0.00,100.00 0.00,93.60 0.00,100.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+
+    <junction id=":C_20_0" type="internal" x="100.00" y="96.27" incLanes=":C_3_0 NC_0 NC_1" intLanes=":C_6_0 :C_6_1 :C_8_0 :C_9_0 :C_10_0 :C_11_0 :C_11_1 :C_16_0 :C_16_1 :C_18_0"/>
+    <junction id=":C_21_0" type="internal" x="100.00" y="91.20" incLanes=":C_4_0 EC_0 NC_0 NC_1 WC_1" intLanes=":C_5_0 :C_11_0 :C_11_1 :C_18_0"/>
+    <junction id=":C_22_0" type="internal" x="103.73" y="100.00" incLanes=":C_8_0 WC_0 WC_1" intLanes=":C_1_0 :C_1_1 :C_3_0 :C_11_0 :C_11_1 :C_13_0 :C_14_0 :C_15_0 :C_16_0 :C_16_1"/>
+    <junction id=":C_23_0" type="internal" x="108.80" y="100.00" incLanes=":C_9_0 NC_0 SC_1 WC_0 WC_1" intLanes=":C_3_0 :C_10_0 :C_16_0 :C_16_1"/>
+    <junction id=":C_24_0" type="internal" x="100.00" y="103.73" incLanes=":C_13_0 SC_0 SC_1" intLanes=":C_0_0 :C_1_0 :C_1_1 :C_6_0 :C_6_1 :C_8_0 :C_16_0 :C_16_1 :C_18_0 :C_19_0"/>
+    <junction id=":C_25_0" type="internal" x="100.00" y="108.80" incLanes=":C_14_0 EC_1 SC_0 SC_1 WC_0" intLanes=":C_1_0 :C_1_1 :C_8_0 :C_15_0"/>
+    <junction id=":C_26_0" type="internal" x="96.27" y="100.00" incLanes=":C_18_0 EC_0 EC_1" intLanes=":C_1_0 :C_1_1 :C_3_0 :C_4_0 :C_5_0 :C_6_0 :C_6_1 :C_11_0 :C_11_1 :C_13_0"/>
+    <junction id=":C_27_0" type="internal" x="91.20" y="100.00" incLanes=":C_19_0 EC_0 EC_1 NC_1 SC_0" intLanes=":C_0_0 :C_6_0 :C_6_1 :C_13_0"/>
+
+    <connection from="CE" to="EC" fromLane="1" toLane="1" via=":E_0_0" dir="T" state="M"/>
+    <connection from="CN" to="NC" fromLane="1" toLane="1" via=":N_0_0" dir="T" state="M"/>
+    <connection from="CS" to="SC" fromLane="1" toLane="1" via=":S_0_0" dir="T" state="M"/>
+    <connection from="CW" to="WC" fromLane="1" toLane="1" via=":W_0_0" dir="T" state="M"/>
+    <connection from="EC" to="CS" fromLane="0" toLane="0" via=":C_5_0" tl="C" linkIndex="5" dir="l" state="o"/>
+    <connection from="EC" to="CW" fromLane="0" toLane="0" via=":C_6_0" tl="C" linkIndex="6" dir="s" state="o"/>
+    <connection from="EC" to="CW" fromLane="1" toLane="1" via=":C_6_1" tl="C" linkIndex="7" dir="s" state="o"/>
+    <connection from="EC" to="CN" fromLane="1" toLane="1" via=":C_8_0" tl="C" linkIndex="8" dir="r" state="o"/>
+    <connection from="EC" to="CE" fromLane="1" toLane="1" via=":C_9_0" tl="C" linkIndex="9" dir="T" state="o"/>
+    <connection from="NC" to="CE" fromLane="0" toLane="0" via=":C_10_0" tl="C" linkIndex="10" dir="l" state="O"/>
+    <connection from="NC" to="CS" fromLane="0" toLane="0" via=":C_11_0" tl="C" linkIndex="11" dir="s" state="O"/>
+    <connection from="NC" to="CS" fromLane="1" toLane="1" via=":C_11_1" tl="C" linkIndex="12" dir="s" state="O"/>
+    <connection from="NC" to="CW" fromLane="1" toLane="1" via=":C_13_0" tl="C" linkIndex="13" dir="r" state="o"/>
+    <connection from="NC" to="CN" fromLane="1" toLane="1" via=":C_14_0" tl="C" linkIndex="14" dir="T" state="o"/>
+    <connection from="SC" to="CW" fromLane="0" toLane="0" via=":C_0_0" tl="C" linkIndex="0" dir="l" state="O"/>
+    <connection from="SC" to="CN" fromLane="0" toLane="0" via=":C_1_0" tl="C" linkIndex="1" dir="s" state="O"/>
+    <connection from="SC" to="CN" fromLane="1" toLane="1" via=":C_1_1" tl="C" linkIndex="2" dir="s" state="O"/>
+    <connection from="SC" to="CE" fromLane="1" toLane="1" via=":C_3_0" tl="C" linkIndex="3" dir="r" state="o"/>
+    <connection from="SC" to="CS" fromLane="1" toLane="1" via=":C_4_0" tl="C" linkIndex="4" dir="T" state="o"/>
+    <connection from="WC" to="CN" fromLane="0" toLane="0" via=":C_15_0" tl="C" linkIndex="15" dir="l" state="o"/>
+    <connection from="WC" to="CE" fromLane="0" toLane="0" via=":C_16_0" tl="C" linkIndex="16" dir="s" state="o"/>
+    <connection from="WC" to="CE" fromLane="1" toLane="1" via=":C_16_1" tl="C" linkIndex="17" dir="s" state="o"/>
+    <connection from="WC" to="CS" fromLane="1" toLane="1" via=":C_18_0" tl="C" linkIndex="18" dir="r" state="o"/>
+    <connection from="WC" to="CW" fromLane="1" toLane="1" via=":C_19_0" tl="C" linkIndex="19" dir="T" state="o"/>
+
+    <connection from=":C_0" to="CW" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":C_1" to="CN" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":C_1" to="CN" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":C_3" to="CE" fromLane="0" toLane="1" via=":C_20_0" dir="r" state="m"/>
+    <connection from=":C_20" to="CE" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":C_4" to="CS" fromLane="0" toLane="1" via=":C_21_0" dir="T" state="m"/>
+    <connection from=":C_21" to="CS" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":C_5" to="CS" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":C_6" to="CW" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":C_6" to="CW" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":C_8" to="CN" fromLane="0" toLane="1" via=":C_22_0" dir="r" state="m"/>
+    <connection from=":C_22" to="CN" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":C_9" to="CE" fromLane="0" toLane="1" via=":C_23_0" dir="T" state="m"/>
+    <connection from=":C_23" to="CE" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":C_10" to="CE" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":C_11" to="CS" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":C_11" to="CS" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":C_13" to="CW" fromLane="0" toLane="1" via=":C_24_0" dir="r" state="m"/>
+    <connection from=":C_24" to="CW" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":C_14" to="CN" fromLane="0" toLane="1" via=":C_25_0" dir="T" state="m"/>
+    <connection from=":C_25" to="CN" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":C_15" to="CN" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":C_16" to="CE" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":C_16" to="CE" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":C_18" to="CS" fromLane="0" toLane="1" via=":C_26_0" dir="r" state="m"/>
+    <connection from=":C_26" to="CS" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":C_19" to="CW" fromLane="0" toLane="1" via=":C_27_0" dir="T" state="m"/>
+    <connection from=":C_27" to="CW" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":E_0" to="EC" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":N_0" to="NC" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":S_0" to="SC" fromLane="0" toLane="1" dir="T" state="M"/>
+    <connection from=":W_0" to="WC" fromLane="0" toLane="1" dir="T" state="M"/>
+
+</net>

--- a/tests/cases/NetXMLSamples/net.net.xml
+++ b/tests/cases/NetXMLSamples/net.net.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Thu Mar 15 14:06:49 2018 by SUMO netconvert Version v0_32_0+0739-234bde1
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
+
+    <input>
+        <node-files value="net.nod.xml"/>
+        <edge-files value="net.edg.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <output-file value="net.net.xml"/>
+    </output>
+
+    <processing>
+        <speed-in-kmh value="true"/>
+        <no-internal-links value="true"/>
+    </processing>
+
+</configuration>
+-->
+
+<net version="0.27" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+
+    <location netOffset="500.00,500.00" convBoundary="0.00,0.00,1000.00,1000.00" origBoundary="-500.00,-500.00,500.00,500.00" projParameter="!"/>
+
+    <edge id="1fi" from="1" to="m1" priority="2">
+        <lane id="1fi_0" index="0" speed="11.11" length="250.00" shape="0.00,498.35 248.50,498.35"/>
+    </edge>
+    <edge id="1o" from="0" to="1" priority="1">
+        <lane id="1o_0" index="0" speed="11.11" length="500.00" shape="488.65,501.65 0.00,501.65"/>
+    </edge>
+    <edge id="1si" from="m1" to="0" priority="3">
+        <lane id="1si_0" index="0" speed="13.89" length="250.00" shape="251.50,491.75 488.65,491.75"/>
+        <lane id="1si_1" index="1" speed="13.89" length="250.00" shape="251.50,495.05 488.65,495.05"/>
+        <lane id="1si_2" index="2" speed="13.89" length="250.00" shape="251.50,498.35 488.65,498.35"/>
+    </edge>
+    <edge id="2fi" from="2" to="m2" priority="2">
+        <lane id="2fi_0" index="0" speed="11.11" length="250.00" shape="1000.00,501.65 751.50,501.65"/>
+    </edge>
+    <edge id="2o" from="0" to="2" priority="1">
+        <lane id="2o_0" index="0" speed="11.11" length="500.00" shape="511.35,498.35 1000.00,498.35"/>
+    </edge>
+    <edge id="2si" from="m2" to="0" priority="3">
+        <lane id="2si_0" index="0" speed="13.89" length="250.00" shape="748.50,508.25 511.35,508.25"/>
+        <lane id="2si_1" index="1" speed="13.89" length="250.00" shape="748.50,504.95 511.35,504.95"/>
+        <lane id="2si_2" index="2" speed="13.89" length="250.00" shape="748.50,501.65 511.35,501.65"/>
+    </edge>
+    <edge id="3fi" from="3" to="m3" priority="2">
+        <lane id="3fi_0" index="0" speed="11.11" length="250.00" shape="501.65,0.00 501.65,248.50"/>
+    </edge>
+    <edge id="3o" from="0" to="3" priority="1">
+        <lane id="3o_0" index="0" speed="11.11" length="500.00" shape="498.35,488.65 498.35,0.00"/>
+    </edge>
+    <edge id="3si" from="m3" to="0" priority="3">
+        <lane id="3si_0" index="0" speed="13.89" length="250.00" shape="508.25,251.50 508.25,488.65"/>
+        <lane id="3si_1" index="1" speed="13.89" length="250.00" shape="504.95,251.50 504.95,488.65"/>
+        <lane id="3si_2" index="2" speed="13.89" length="250.00" shape="501.65,251.50 501.65,488.65"/>
+    </edge>
+    <edge id="4fi" from="4" to="m4" priority="2">
+        <lane id="4fi_0" index="0" speed="11.11" length="250.00" shape="498.35,1000.00 498.35,751.50"/>
+    </edge>
+    <edge id="4o" from="0" to="4" priority="1">
+        <lane id="4o_0" index="0" speed="11.11" length="500.00" shape="501.65,511.35 501.65,1000.00"/>
+    </edge>
+    <edge id="4si" from="m4" to="0" priority="3">
+        <lane id="4si_0" index="0" speed="13.89" length="250.00" shape="491.75,748.50 491.75,511.35"/>
+        <lane id="4si_1" index="1" speed="13.89" length="250.00" shape="495.05,748.50 495.05,511.35"/>
+        <lane id="4si_2" index="2" speed="13.89" length="250.00" shape="498.35,748.50 498.35,511.35"/>
+    </edge>
+
+    <tlLogic id="0" type="static" programID="0" offset="0">
+        <phase duration="33" state="GGggrrrrGGggrrrr"/>
+        <phase duration="3"  state="yyggrrrryyggrrrr"/>
+        <phase duration="6"  state="rrGGrrrrrrGGrrrr"/>
+        <phase duration="3"  state="rryyrrrrrryyrrrr"/>
+        <phase duration="33" state="rrrrGGggrrrrGGgg"/>
+        <phase duration="3"  state="rrrryyggrrrryygg"/>
+        <phase duration="6"  state="rrrrrrGGrrrrrrGG"/>
+        <phase duration="3"  state="rrrrrryyrrrrrryy"/>
+    </tlLogic>
+
+    <junction id="0" type="traffic_light" x="500.00" y="500.00" incLanes="4si_0 4si_1 4si_2 2si_0 2si_1 2si_2 3si_0 3si_1 3si_2 1si_0 1si_1 1si_2" intLanes="" shape="490.15,511.35 503.25,511.35 511.35,509.85 511.35,496.75 509.85,488.65 496.75,488.65 488.65,490.15 488.65,503.25">
+        <request index="0"  response="0000000000000000" foes="1000010000100000"/>
+        <request index="1"  response="0000000000000000" foes="0111110001100000"/>
+        <request index="2"  response="0000001100000000" foes="0110001111100000"/>
+        <request index="3"  response="0100001000010000" foes="0100001000010000"/>
+        <request index="4"  response="0000001000000000" foes="0100001000001000"/>
+        <request index="5"  response="0000011000000111" foes="1100011000000111"/>
+        <request index="6"  response="0011011000000110" foes="0011111000000110"/>
+        <request index="7"  response="0010000100000100" foes="0010000100000100"/>
+        <request index="8"  response="0000000000000000" foes="0010000010000100"/>
+        <request index="9"  response="0000000000000000" foes="0110000001111100"/>
+        <request index="10" response="0000000000000011" foes="1110000001100011"/>
+        <request index="11" response="0001000001000010" foes="0001000001000010"/>
+        <request index="12" response="0000000000000010" foes="0000100001000010"/>
+        <request index="13" response="0000011100000110" foes="0000011111000110"/>
+        <request index="14" response="0000011000110110" foes="0000011000111110"/>
+        <request index="15" response="0000010000100001" foes="0000010000100001"/>
+    </junction>
+    <junction id="1" type="priority" x="0.00" y="500.00" incLanes="1o_0" intLanes="" shape="0.00,499.95 0.00,503.25 0.00,500.05">
+        <request index="0" response="0" foes="0"/>
+    </junction>
+    <junction id="2" type="priority" x="1000.00" y="500.00" incLanes="2o_0" intLanes="" shape="1000.00,500.05 1000.00,496.75 1000.00,499.95">
+        <request index="0" response="0" foes="0"/>
+    </junction>
+    <junction id="3" type="priority" x="500.00" y="0.00" incLanes="3o_0" intLanes="" shape="500.05,0.00 496.75,0.00 499.95,0.00">
+        <request index="0" response="0" foes="0"/>
+    </junction>
+    <junction id="4" type="priority" x="500.00" y="1000.00" incLanes="4o_0" intLanes="" shape="499.95,1000.00 503.25,1000.00 500.05,1000.00">
+        <request index="0" response="0" foes="0"/>
+    </junction>
+    <junction id="m1" type="priority" x="250.00" y="500.00" incLanes="1fi_0" intLanes="" shape="251.50,499.95 251.50,490.15 248.50,496.75 248.50,499.95">
+        <request index="0" response="000" foes="000"/>
+        <request index="1" response="000" foes="000"/>
+        <request index="2" response="000" foes="000"/>
+    </junction>
+    <junction id="m2" type="priority" x="750.00" y="500.00" incLanes="2fi_0" intLanes="" shape="751.50,503.25 751.50,500.05 748.50,500.05 748.50,509.85">
+        <request index="0" response="000" foes="000"/>
+        <request index="1" response="000" foes="000"/>
+        <request index="2" response="000" foes="000"/>
+    </junction>
+    <junction id="m3" type="priority" x="500.00" y="250.00" incLanes="3fi_0" intLanes="" shape="500.05,251.50 509.85,251.50 503.25,248.50 500.05,248.50">
+        <request index="0" response="000" foes="000"/>
+        <request index="1" response="000" foes="000"/>
+        <request index="2" response="000" foes="000"/>
+    </junction>
+    <junction id="m4" type="priority" x="500.00" y="750.00" incLanes="4fi_0" intLanes="" shape="496.75,751.50 499.95,751.50 499.95,748.50 490.15,748.50">
+        <request index="0" response="000" foes="000"/>
+        <request index="1" response="000" foes="000"/>
+        <request index="2" response="000" foes="000"/>
+    </junction>
+
+    <connection from="1fi" to="1si" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="1fi" to="1si" fromLane="0" toLane="1" dir="s" state="M"/>
+    <connection from="1fi" to="1si" fromLane="0" toLane="2" dir="s" state="M"/>
+    <connection from="1o" to="1fi" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from="1si" to="3o" fromLane="0" toLane="0" tl="0" linkIndex="12" dir="r" state="o"/>
+    <connection from="1si" to="2o" fromLane="1" toLane="0" tl="0" linkIndex="13" dir="s" state="o"/>
+    <connection from="1si" to="4o" fromLane="2" toLane="0" tl="0" linkIndex="14" dir="l" state="o"/>
+    <connection from="1si" to="1o" fromLane="2" toLane="0" tl="0" linkIndex="15" dir="t" state="o"/>
+    <connection from="2fi" to="2si" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="2fi" to="2si" fromLane="0" toLane="1" dir="s" state="M"/>
+    <connection from="2fi" to="2si" fromLane="0" toLane="2" dir="s" state="M"/>
+    <connection from="2o" to="2fi" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from="2si" to="4o" fromLane="0" toLane="0" tl="0" linkIndex="4" dir="r" state="o"/>
+    <connection from="2si" to="1o" fromLane="1" toLane="0" tl="0" linkIndex="5" dir="s" state="o"/>
+    <connection from="2si" to="3o" fromLane="2" toLane="0" tl="0" linkIndex="6" dir="l" state="o"/>
+    <connection from="2si" to="2o" fromLane="2" toLane="0" tl="0" linkIndex="7" dir="t" state="o"/>
+    <connection from="3fi" to="3si" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="3fi" to="3si" fromLane="0" toLane="1" dir="s" state="M"/>
+    <connection from="3fi" to="3si" fromLane="0" toLane="2" dir="s" state="M"/>
+    <connection from="3o" to="3fi" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from="3si" to="2o" fromLane="0" toLane="0" tl="0" linkIndex="8" dir="r" state="O"/>
+    <connection from="3si" to="4o" fromLane="1" toLane="0" tl="0" linkIndex="9" dir="s" state="O"/>
+    <connection from="3si" to="1o" fromLane="2" toLane="0" tl="0" linkIndex="10" dir="l" state="o"/>
+    <connection from="3si" to="3o" fromLane="2" toLane="0" tl="0" linkIndex="11" dir="t" state="o"/>
+    <connection from="4fi" to="4si" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="4fi" to="4si" fromLane="0" toLane="1" dir="s" state="M"/>
+    <connection from="4fi" to="4si" fromLane="0" toLane="2" dir="s" state="M"/>
+    <connection from="4o" to="4fi" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from="4si" to="1o" fromLane="0" toLane="0" tl="0" linkIndex="0" dir="r" state="O"/>
+    <connection from="4si" to="3o" fromLane="1" toLane="0" tl="0" linkIndex="1" dir="s" state="O"/>
+    <connection from="4si" to="2o" fromLane="2" toLane="0" tl="0" linkIndex="2" dir="l" state="o"/>
+    <connection from="4si" to="4o" fromLane="2" toLane="0" tl="0" linkIndex="3" dir="t" state="o"/>
+
+</net>

--- a/tests/cases/NetXMLSamples/roundabout.net.xml
+++ b/tests/cases/NetXMLSamples/roundabout.net.xml
@@ -1,79 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <net version="1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
-    <location netOffset="0.00,0.00" convBoundary="-200.00,-200.00,200.00,200.00" origBoundary="-200.00,-200.00,200.00,200.00" projParameter="!"/>
+    <location netOffset="0.00,0.00" convBoundary="-80.00,-80.00,80.00,80.00" origBoundary="-80.00,-80.00,80.00,80.00" projParameter="!"/>
 
-    <!-- roundabout nodes -->
-    <edge id=":r0_0" function="internal"><lane id=":r0_0_0" index="0" speed="8.00" length="19.63" shape="15.00,3.00 12.99,9.00 9.00,13.00 3.00,15.00"/></edge>
-    <edge id=":r1_0" function="internal"><lane id=":r1_0_0" index="0" speed="8.00" length="19.63" shape="-3.00,15.00 -9.00,13.00 -13.00,9.00 -15.00,3.00"/></edge>
-    <edge id=":r2_0" function="internal"><lane id=":r2_0_0" index="0" speed="8.00" length="19.63" shape="-15.00,-3.00 -13.00,-9.00 -9.00,-13.00 -3.00,-15.00"/></edge>
-    <edge id=":r3_0" function="internal"><lane id=":r3_0_0" index="0" speed="8.00" length="19.63" shape="3.00,-15.00 9.00,-13.00 13.00,-9.00 15.00,-3.00"/></edge>
-    <edge id=":n_0" function="internal"><lane id=":n_0_0" index="0" speed="8.00" length="5.00" shape="0.00,100.00 0.00,20.00"/></edge>
-    <edge id=":s_0" function="internal"><lane id=":s_0_0" index="0" speed="8.00" length="5.00" shape="0.00,-20.00 0.00,-100.00"/></edge>
-    <edge id=":e_0" function="internal"><lane id=":e_0_0" index="0" speed="8.00" length="5.00" shape="100.00,0.00 20.00,0.00"/></edge>
-    <edge id=":w_0" function="internal"><lane id=":w_0_0" index="0" speed="8.00" length="5.00" shape="-20.00,0.00 -100.00,0.00"/></edge>
+    <!-- internal edges (junction connectors) -->
+    <edge id=":r0_0" function="internal">
+        <lane id=":r0_0_0" index="0" speed="8.00" length="15.71" width="3.50"
+              shape="20.00,4.00 17.32,12.00 12.00,17.32 4.00,20.00"/>
+    </edge>
+    <edge id=":r1_0" function="internal">
+        <lane id=":r1_0_0" index="0" speed="8.00" length="15.71" width="3.50"
+              shape="-4.00,20.00 -12.00,17.32 -17.32,12.00 -20.00,4.00"/>
+    </edge>
+    <edge id=":r2_0" function="internal">
+        <lane id=":r2_0_0" index="0" speed="8.00" length="15.71" width="3.50"
+              shape="-20.00,-4.00 -17.32,-12.00 -12.00,-17.32 -4.00,-20.00"/>
+    </edge>
+    <edge id=":r3_0" function="internal">
+        <lane id=":r3_0_0" index="0" speed="8.00" length="15.71" width="3.50"
+              shape="4.00,-20.00 12.00,-17.32 17.32,-12.00 20.00,-4.00"/>
+    </edge>
 
-    <!-- approach roads -->
+    <!-- approach roads: two lanes each (in + out) so width estimation works -->
     <edge id="north_in" from="north" to="r0" priority="1">
-        <lane id="north_in_0" index="0" speed="13.89" length="80.00" shape="0.00,100.00 0.00,20.00"/>
+        <lane id="north_in_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="-1.75,70.00 -1.75,24.00"/>
+        <lane id="north_in_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="1.75,70.00 1.75,24.00"/>
     </edge>
     <edge id="north_out" from="r1" to="north" priority="1">
-        <lane id="north_out_0" index="0" speed="13.89" length="80.00" shape="0.00,20.00 0.00,100.00"/>
+        <lane id="north_out_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="-1.75,24.00 -1.75,70.00"/>
+        <lane id="north_out_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="1.75,24.00 1.75,70.00"/>
     </edge>
     <edge id="south_in" from="south" to="r2" priority="1">
-        <lane id="south_in_0" index="0" speed="13.89" length="80.00" shape="0.00,-100.00 0.00,-20.00"/>
+        <lane id="south_in_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="1.75,-70.00 1.75,-24.00"/>
+        <lane id="south_in_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="-1.75,-70.00 -1.75,-24.00"/>
     </edge>
     <edge id="south_out" from="r3" to="south" priority="1">
-        <lane id="south_out_0" index="0" speed="13.89" length="80.00" shape="0.00,-20.00 0.00,-100.00"/>
+        <lane id="south_out_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="1.75,-24.00 1.75,-70.00"/>
+        <lane id="south_out_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="-1.75,-24.00 -1.75,-70.00"/>
     </edge>
     <edge id="east_in" from="east" to="r1" priority="1">
-        <lane id="east_in_0" index="0" speed="13.89" length="80.00" shape="100.00,0.00 20.00,0.00"/>
+        <lane id="east_in_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="70.00,-1.75 24.00,-1.75"/>
+        <lane id="east_in_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="70.00,1.75 24.00,1.75"/>
     </edge>
     <edge id="east_out" from="r0" to="east" priority="1">
-        <lane id="east_out_0" index="0" speed="13.89" length="80.00" shape="20.00,0.00 100.00,0.00"/>
+        <lane id="east_out_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="24.00,-1.75 70.00,-1.75"/>
+        <lane id="east_out_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="24.00,1.75 70.00,1.75"/>
     </edge>
     <edge id="west_in" from="west" to="r3" priority="1">
-        <lane id="west_in_0" index="0" speed="13.89" length="80.00" shape="-100.00,0.00 -20.00,0.00"/>
+        <lane id="west_in_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="-70.00,1.75 -24.00,1.75"/>
+        <lane id="west_in_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="-70.00,-1.75 -24.00,-1.75"/>
     </edge>
     <edge id="west_out" from="r2" to="west" priority="1">
-        <lane id="west_out_0" index="0" speed="13.89" length="80.00" shape="-20.00,0.00 -100.00,0.00"/>
+        <lane id="west_out_0" index="0" speed="13.89" length="50.00" width="3.50"
+              shape="-24.00,1.75 -70.00,1.75"/>
+        <lane id="west_out_1" index="1" speed="13.89" length="50.00" width="3.50"
+              shape="-24.00,-1.75 -70.00,-1.75"/>
     </edge>
 
-    <!-- roundabout internal edges -->
+    <!-- roundabout ring: two lanes so width estimation works -->
     <edge id="ring_ne" from="r0" to="r1" priority="2">
-        <lane id="ring_ne_0" index="0" speed="8.00" length="31.42" shape="15.00,3.00 12.99,9.00 9.00,13.00 3.00,15.00 -3.00,15.00"/>
+        <lane id="ring_ne_0" index="0" speed="8.00" length="34.56" width="3.50"
+              shape="20.00,4.00 17.32,12.00 12.00,17.32 4.00,20.00 -4.00,20.00"/>
+        <lane id="ring_ne_1" index="1" speed="8.00" length="31.42" width="3.50"
+              shape="16.00,3.20 13.86,9.60 9.60,13.86 3.20,16.00 -3.20,16.00"/>
     </edge>
     <edge id="ring_nw" from="r1" to="r2" priority="2">
-        <lane id="ring_nw_0" index="0" speed="8.00" length="31.42" shape="-3.00,15.00 -9.00,13.00 -13.00,9.00 -15.00,3.00 -15.00,-3.00"/>
+        <lane id="ring_nw_0" index="0" speed="8.00" length="34.56" width="3.50"
+              shape="-4.00,20.00 -12.00,17.32 -17.32,12.00 -20.00,4.00 -20.00,-4.00"/>
+        <lane id="ring_nw_1" index="1" speed="8.00" length="31.42" width="3.50"
+              shape="-3.20,16.00 -9.60,13.86 -13.86,9.60 -16.00,3.20 -16.00,-3.20"/>
     </edge>
     <edge id="ring_sw" from="r2" to="r3" priority="2">
-        <lane id="ring_sw_0" index="0" speed="8.00" length="31.42" shape="-15.00,-3.00 -13.00,-9.00 -9.00,-13.00 -3.00,-15.00 3.00,-15.00"/>
+        <lane id="ring_sw_0" index="0" speed="8.00" length="34.56" width="3.50"
+              shape="-20.00,-4.00 -17.32,-12.00 -12.00,-17.32 -4.00,-20.00 4.00,-20.00"/>
+        <lane id="ring_sw_1" index="1" speed="8.00" length="31.42" width="3.50"
+              shape="-16.00,-3.20 -13.86,-9.60 -9.60,-13.86 -3.20,-16.00 3.20,-16.00"/>
     </edge>
     <edge id="ring_se" from="r3" to="r0" priority="2">
-        <lane id="ring_se_0" index="0" speed="8.00" length="31.42" shape="3.00,-15.00 9.00,-13.00 13.00,-9.00 15.00,-3.00 15.00,3.00"/>
+        <lane id="ring_se_0" index="0" speed="8.00" length="34.56" width="3.50"
+              shape="4.00,-20.00 12.00,-17.32 17.32,-12.00 20.00,-4.00 20.00,4.00"/>
+        <lane id="ring_se_1" index="1" speed="8.00" length="31.42" width="3.50"
+              shape="3.20,-16.00 9.60,-13.86 13.86,-9.60 16.00,-3.20 16.00,3.20"/>
     </edge>
 
     <!-- junctions -->
-    <junction id="north" type="dead_end" x="0.00" y="100.00" incLanes="north_out_0" intLanes="" shape="5.00,100.00 -5.00,100.00"/>
-    <junction id="south" type="dead_end" x="0.00" y="-100.00" incLanes="south_out_0" intLanes="" shape="-5.00,-100.00 5.00,-100.00"/>
-    <junction id="east" type="dead_end" x="100.00" y="0.00" incLanes="east_out_0" intLanes="" shape="100.00,5.00 100.00,-5.00"/>
-    <junction id="west" type="dead_end" x="-100.00" y="0.00" incLanes="west_out_0" intLanes="" shape="-100.00,-5.00 -100.00,5.00"/>
-    <junction id="r0" type="priority" x="15.00" y="0.00" incLanes="north_in_0 ring_se_0" intLanes=":r0_0_0" shape="20.00,5.00 10.00,5.00 10.00,-5.00 20.00,-5.00"/>
-    <junction id="r1" type="priority" x="0.00" y="15.00" incLanes="east_in_0 ring_ne_0" intLanes=":r1_0_0" shape="5.00,20.00 5.00,10.00 -5.00,10.00 -5.00,20.00"/>
-    <junction id="r2" type="priority" x="-15.00" y="0.00" incLanes="ring_nw_0" intLanes=":r2_0_0" shape="-10.00,5.00 -20.00,5.00 -20.00,-5.00 -10.00,-5.00"/>
-    <junction id="r3" type="priority" x="0.00" y="-15.00" incLanes="west_in_0 ring_sw_0" intLanes=":r3_0_0" shape="-5.00,-10.00 -5.00,-20.00 5.00,-20.00 5.00,-10.00"/>
+    <junction id="north" type="dead_end" x="0.00" y="70.00"
+              incLanes="north_out_0 north_out_1" intLanes=""
+              shape="5.25,70.00 -5.25,70.00"/>
+    <junction id="south" type="dead_end" x="0.00" y="-70.00"
+              incLanes="south_out_0 south_out_1" intLanes=""
+              shape="-5.25,-70.00 5.25,-70.00"/>
+    <junction id="east" type="dead_end" x="70.00" y="0.00"
+              incLanes="east_out_0 east_out_1" intLanes=""
+              shape="70.00,5.25 70.00,-5.25"/>
+    <junction id="west" type="dead_end" x="-70.00" y="0.00"
+              incLanes="west_out_0 west_out_1" intLanes=""
+              shape="-70.00,-5.25 -70.00,5.25"/>
+    <junction id="r0" type="priority" x="20.00" y="0.00"
+              incLanes="north_in_0 north_in_1 ring_se_0 ring_se_1" intLanes=":r0_0_0"
+              shape="25.00,7.00 12.00,7.00 12.00,-7.00 25.00,-7.00"/>
+    <junction id="r1" type="priority" x="0.00" y="20.00"
+              incLanes="east_in_0 east_in_1 ring_ne_0 ring_ne_1" intLanes=":r1_0_0"
+              shape="7.00,25.00 7.00,12.00 -7.00,12.00 -7.00,25.00"/>
+    <junction id="r2" type="priority" x="-20.00" y="0.00"
+              incLanes="ring_nw_0 ring_nw_1" intLanes=":r2_0_0"
+              shape="-12.00,7.00 -25.00,7.00 -25.00,-7.00 -12.00,-7.00"/>
+    <junction id="r3" type="priority" x="0.00" y="-20.00"
+              incLanes="west_in_0 west_in_1 ring_sw_0 ring_sw_1" intLanes=":r3_0_0"
+              shape="-7.00,-12.00 -7.00,-25.00 7.00,-25.00 7.00,-12.00"/>
 
     <!-- connections -->
     <connection from="north_in" to="ring_ne" fromLane="0" toLane="0" via=":r0_0_0" dir="s" state="M"/>
-    <connection from="ring_se" to="east_out" fromLane="0" toLane="0" via=":r0_0_0" dir="r" state="M"/>
-    <connection from="east_in" to="ring_nw" fromLane="0" toLane="0" via=":r1_0_0" dir="s" state="M"/>
-    <connection from="ring_ne" to="north_out" fromLane="0" toLane="0" via=":r1_0_0" dir="r" state="M"/>
-    <connection from="ring_nw" to="west_out" fromLane="0" toLane="0" via=":r2_0_0" dir="r" state="M"/>
-    <connection from="west_in" to="ring_sw" fromLane="0" toLane="0" via=":r3_0_0" dir="s" state="M"/>
-    <connection from="ring_sw" to="south_out" fromLane="0" toLane="0" via=":r3_0_0" dir="r" state="M"/>
-    <connection from="ring_ne" to="ring_nw" fromLane="0" toLane="0" dir="s" state="M"/>
-    <connection from="ring_nw" to="ring_sw" fromLane="0" toLane="0" dir="s" state="M"/>
-    <connection from="ring_sw" to="ring_se" fromLane="0" toLane="0" dir="s" state="M"/>
-    <connection from="ring_se" to="ring_ne" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="north_in" to="ring_ne" fromLane="1" toLane="1" via=":r0_0_0" dir="s" state="M"/>
+    <connection from="ring_se"  to="east_out" fromLane="0" toLane="0" via=":r0_0_0" dir="r" state="M"/>
+    <connection from="ring_se"  to="east_out" fromLane="1" toLane="1" via=":r0_0_0" dir="r" state="M"/>
+    <connection from="east_in"  to="ring_nw" fromLane="0" toLane="0" via=":r1_0_0" dir="s" state="M"/>
+    <connection from="east_in"  to="ring_nw" fromLane="1" toLane="1" via=":r1_0_0" dir="s" state="M"/>
+    <connection from="ring_ne"  to="north_out" fromLane="0" toLane="0" via=":r1_0_0" dir="r" state="M"/>
+    <connection from="ring_ne"  to="north_out" fromLane="1" toLane="1" via=":r1_0_0" dir="r" state="M"/>
+    <connection from="ring_nw"  to="west_out" fromLane="0" toLane="0" via=":r2_0_0" dir="r" state="M"/>
+    <connection from="ring_nw"  to="west_out" fromLane="1" toLane="1" via=":r2_0_0" dir="r" state="M"/>
+    <connection from="west_in"  to="ring_sw" fromLane="0" toLane="0" via=":r3_0_0" dir="s" state="M"/>
+    <connection from="west_in"  to="ring_sw" fromLane="1" toLane="1" via=":r3_0_0" dir="s" state="M"/>
+    <connection from="ring_sw"  to="south_out" fromLane="0" toLane="0" via=":r3_0_0" dir="r" state="M"/>
+    <connection from="ring_sw"  to="south_out" fromLane="1" toLane="1" via=":r3_0_0" dir="r" state="M"/>
+    <connection from="ring_ne"  to="ring_nw" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_ne"  to="ring_nw" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from="ring_nw"  to="ring_sw" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_nw"  to="ring_sw" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from="ring_sw"  to="ring_se" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_sw"  to="ring_se" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from="ring_se"  to="ring_ne" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_se"  to="ring_ne" fromLane="1" toLane="1" dir="s" state="M"/>
 
     <roundabout nodes="r0 r1 r2 r3" edges="ring_ne ring_nw ring_sw ring_se"/>
 </net>

--- a/tests/cases/NetXMLSamples/roundabout.net.xml
+++ b/tests/cases/NetXMLSamples/roundabout.net.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<net version="1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+    <location netOffset="0.00,0.00" convBoundary="-200.00,-200.00,200.00,200.00" origBoundary="-200.00,-200.00,200.00,200.00" projParameter="!"/>
+
+    <!-- roundabout nodes -->
+    <edge id=":r0_0" function="internal"><lane id=":r0_0_0" index="0" speed="8.00" length="19.63" shape="15.00,3.00 12.99,9.00 9.00,13.00 3.00,15.00"/></edge>
+    <edge id=":r1_0" function="internal"><lane id=":r1_0_0" index="0" speed="8.00" length="19.63" shape="-3.00,15.00 -9.00,13.00 -13.00,9.00 -15.00,3.00"/></edge>
+    <edge id=":r2_0" function="internal"><lane id=":r2_0_0" index="0" speed="8.00" length="19.63" shape="-15.00,-3.00 -13.00,-9.00 -9.00,-13.00 -3.00,-15.00"/></edge>
+    <edge id=":r3_0" function="internal"><lane id=":r3_0_0" index="0" speed="8.00" length="19.63" shape="3.00,-15.00 9.00,-13.00 13.00,-9.00 15.00,-3.00"/></edge>
+    <edge id=":n_0" function="internal"><lane id=":n_0_0" index="0" speed="8.00" length="5.00" shape="0.00,100.00 0.00,20.00"/></edge>
+    <edge id=":s_0" function="internal"><lane id=":s_0_0" index="0" speed="8.00" length="5.00" shape="0.00,-20.00 0.00,-100.00"/></edge>
+    <edge id=":e_0" function="internal"><lane id=":e_0_0" index="0" speed="8.00" length="5.00" shape="100.00,0.00 20.00,0.00"/></edge>
+    <edge id=":w_0" function="internal"><lane id=":w_0_0" index="0" speed="8.00" length="5.00" shape="-20.00,0.00 -100.00,0.00"/></edge>
+
+    <!-- approach roads -->
+    <edge id="north_in" from="north" to="r0" priority="1">
+        <lane id="north_in_0" index="0" speed="13.89" length="80.00" shape="0.00,100.00 0.00,20.00"/>
+    </edge>
+    <edge id="north_out" from="r1" to="north" priority="1">
+        <lane id="north_out_0" index="0" speed="13.89" length="80.00" shape="0.00,20.00 0.00,100.00"/>
+    </edge>
+    <edge id="south_in" from="south" to="r2" priority="1">
+        <lane id="south_in_0" index="0" speed="13.89" length="80.00" shape="0.00,-100.00 0.00,-20.00"/>
+    </edge>
+    <edge id="south_out" from="r3" to="south" priority="1">
+        <lane id="south_out_0" index="0" speed="13.89" length="80.00" shape="0.00,-20.00 0.00,-100.00"/>
+    </edge>
+    <edge id="east_in" from="east" to="r1" priority="1">
+        <lane id="east_in_0" index="0" speed="13.89" length="80.00" shape="100.00,0.00 20.00,0.00"/>
+    </edge>
+    <edge id="east_out" from="r0" to="east" priority="1">
+        <lane id="east_out_0" index="0" speed="13.89" length="80.00" shape="20.00,0.00 100.00,0.00"/>
+    </edge>
+    <edge id="west_in" from="west" to="r3" priority="1">
+        <lane id="west_in_0" index="0" speed="13.89" length="80.00" shape="-100.00,0.00 -20.00,0.00"/>
+    </edge>
+    <edge id="west_out" from="r2" to="west" priority="1">
+        <lane id="west_out_0" index="0" speed="13.89" length="80.00" shape="-20.00,0.00 -100.00,0.00"/>
+    </edge>
+
+    <!-- roundabout internal edges -->
+    <edge id="ring_ne" from="r0" to="r1" priority="2">
+        <lane id="ring_ne_0" index="0" speed="8.00" length="31.42" shape="15.00,3.00 12.99,9.00 9.00,13.00 3.00,15.00 -3.00,15.00"/>
+    </edge>
+    <edge id="ring_nw" from="r1" to="r2" priority="2">
+        <lane id="ring_nw_0" index="0" speed="8.00" length="31.42" shape="-3.00,15.00 -9.00,13.00 -13.00,9.00 -15.00,3.00 -15.00,-3.00"/>
+    </edge>
+    <edge id="ring_sw" from="r2" to="r3" priority="2">
+        <lane id="ring_sw_0" index="0" speed="8.00" length="31.42" shape="-15.00,-3.00 -13.00,-9.00 -9.00,-13.00 -3.00,-15.00 3.00,-15.00"/>
+    </edge>
+    <edge id="ring_se" from="r3" to="r0" priority="2">
+        <lane id="ring_se_0" index="0" speed="8.00" length="31.42" shape="3.00,-15.00 9.00,-13.00 13.00,-9.00 15.00,-3.00 15.00,3.00"/>
+    </edge>
+
+    <!-- junctions -->
+    <junction id="north" type="dead_end" x="0.00" y="100.00" incLanes="north_out_0" intLanes="" shape="5.00,100.00 -5.00,100.00"/>
+    <junction id="south" type="dead_end" x="0.00" y="-100.00" incLanes="south_out_0" intLanes="" shape="-5.00,-100.00 5.00,-100.00"/>
+    <junction id="east" type="dead_end" x="100.00" y="0.00" incLanes="east_out_0" intLanes="" shape="100.00,5.00 100.00,-5.00"/>
+    <junction id="west" type="dead_end" x="-100.00" y="0.00" incLanes="west_out_0" intLanes="" shape="-100.00,-5.00 -100.00,5.00"/>
+    <junction id="r0" type="priority" x="15.00" y="0.00" incLanes="north_in_0 ring_se_0" intLanes=":r0_0_0" shape="20.00,5.00 10.00,5.00 10.00,-5.00 20.00,-5.00"/>
+    <junction id="r1" type="priority" x="0.00" y="15.00" incLanes="east_in_0 ring_ne_0" intLanes=":r1_0_0" shape="5.00,20.00 5.00,10.00 -5.00,10.00 -5.00,20.00"/>
+    <junction id="r2" type="priority" x="-15.00" y="0.00" incLanes="ring_nw_0" intLanes=":r2_0_0" shape="-10.00,5.00 -20.00,5.00 -20.00,-5.00 -10.00,-5.00"/>
+    <junction id="r3" type="priority" x="0.00" y="-15.00" incLanes="west_in_0 ring_sw_0" intLanes=":r3_0_0" shape="-5.00,-10.00 -5.00,-20.00 5.00,-20.00 5.00,-10.00"/>
+
+    <!-- connections -->
+    <connection from="north_in" to="ring_ne" fromLane="0" toLane="0" via=":r0_0_0" dir="s" state="M"/>
+    <connection from="ring_se" to="east_out" fromLane="0" toLane="0" via=":r0_0_0" dir="r" state="M"/>
+    <connection from="east_in" to="ring_nw" fromLane="0" toLane="0" via=":r1_0_0" dir="s" state="M"/>
+    <connection from="ring_ne" to="north_out" fromLane="0" toLane="0" via=":r1_0_0" dir="r" state="M"/>
+    <connection from="ring_nw" to="west_out" fromLane="0" toLane="0" via=":r2_0_0" dir="r" state="M"/>
+    <connection from="west_in" to="ring_sw" fromLane="0" toLane="0" via=":r3_0_0" dir="s" state="M"/>
+    <connection from="ring_sw" to="south_out" fromLane="0" toLane="0" via=":r3_0_0" dir="r" state="M"/>
+    <connection from="ring_ne" to="ring_nw" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_nw" to="ring_sw" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_sw" to="ring_se" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="ring_se" to="ring_ne" fromLane="0" toLane="0" dir="s" state="M"/>
+
+    <roundabout nodes="r0 r1 r2 r3" edges="ring_ne ring_nw ring_sw ring_se"/>
+</net>

--- a/tests/test_map_element.py
+++ b/tests/test_map_element.py
@@ -66,13 +66,13 @@ def test_lane():
 
 @pytest.mark.map_element
 def test_junction():
-    connection1 = map_element.Connection(
+    connection1 = map_element.Junction(
         id_="1", incoming_road="2", connecting_road="3", contact_point="start", lane_links=[]
     )
-    connection2 = map_element.Connection(
+    connection2 = map_element.Junction(
         id_="2", incoming_road="4", connecting_road="5", contact_point="end", lane_links=[]
     )
-    junction = map_element.Junction(id_="1", connections={connection1.id_: connection1})
+    junction = map_element.Junction(id_="0", connections={connection1.id_: connection1})
     junction.add_connection(connection2)
     assert len(junction.connections) == 2
 

--- a/tests/test_map_parser.py
+++ b/tests/test_map_parser.py
@@ -138,6 +138,7 @@ def test_xodr_parser(map_path, img_path):
     [
         ("./tests/cases/NetXMLSamples/net.net.xml", "./tests/runtime/net.png"),
         ("./tests/cases/NetXMLSamples/lefthand.net.xml", "./tests/runtime/lefthand.png"),
+        ("./tests/cases/NetXMLSamples/roundabout.net.xml", "./tests/runtime/roundabout.png"),
     ],
 )
 def test_net_xml_parser(map_path, img_path):
@@ -158,3 +159,4 @@ def test_net_xml_parser(map_path, img_path):
 
     matplotlib_renderer.update(geometry_data)
     matplotlib_renderer.save_single_frame(save_to=img_path)
+    matplotlib_renderer.destroy()

--- a/tests/test_map_parser.py
+++ b/tests/test_map_parser.py
@@ -15,7 +15,7 @@ import pytest
 from shapely.geometry import Point
 
 from tactics2d.map.map_config import *
-from tactics2d.map.parser import OSMParser, XODRParser
+from tactics2d.map.parser import NetXMLParser, OSMParser, XODRParser
 from tactics2d.renderer import MatplotlibRenderer
 from tactics2d.sensor import BEVCamera
 from tactics2d.utils.common import get_absolute_path
@@ -115,6 +115,34 @@ def test_lanelet2_parser(map_folder, map_configs):
 def test_xodr_parser(map_path, img_path):
     map_path = get_absolute_path(map_path)
     map_parser = XODRParser()
+    map_ = map_parser.parse(map_path)
+
+    boundary = map_.boundary
+    camera = BEVCamera(1, map_)
+    position = Point(0, 0)
+    geometry_data, _, _ = camera.update(0, None, None, None, None, position)
+
+    matplotlib_renderer = MatplotlibRenderer(
+        resolution=((boundary[1] - boundary[0]) * 10, (boundary[3] - boundary[2]) * 10),
+        xlim=(boundary[0], boundary[1]),
+        ylim=(boundary[2], boundary[3]),
+    )
+
+    matplotlib_renderer.update(geometry_data)
+    matplotlib_renderer.save_single_frame(save_to=img_path)
+
+
+@pytest.mark.map_parser
+@pytest.mark.parametrize(
+    "map_path, img_path",
+    [
+        ("./tests/cases/NetXMLSamples/net.net.xml", "./tests/runtime/net.png"),
+        ("./tests/cases/NetXMLSamples/lefthand.net.xml", "./tests/runtime/lefthand.png"),
+    ],
+)
+def test_net_xml_parser(map_path, img_path):
+    map_path = get_absolute_path(map_path)
+    map_parser = NetXMLParser()
     map_ = map_parser.parse(map_path)
 
     boundary = map_.boundary


### PR DESCRIPTION
## Overview

This PR completes the native SUMO network map parser for Tactics2D. Building on the initial implementation, this update merges the `Connection` class into `Junction`, adds junction shape auto-completion and rendering, and fixes formatting issues per review feedback.

## Core Contributions

### Junction class (`tactics2d/map/element/junction.py`)

- Merged `Connection` class into `Junction` by directly incorporating its properties (`incoming_road`, `connecting_road`, `contact_point`, `lane_links`) and `add_lane_link()` with default values
- Added `custom_tags` field to support format-specific metadata
- Fixed mutable default argument bug in both classes (`lane_links=[]` → `None`, `connections={}` → `None`)
- `incoming_road` and `connecting_road` made optional to support non-OpenDRIVE formats

### SUMO Network Parser (`tactics2d/map/parser/parse_net_xml.py`)

- Implements `NetXMLParser` using `defusedxml.ElementTree` to directly parse SUMO `.net.xml` files without any external SUMO dependencies
- Maps SUMO edges and lanes to Tactics2D `Lane`, `RoadLine`, and `Junction` objects
- Lane width estimated from adjacent lane geometry when multiple lanes exist per edge, falls back to 3.2 m otherwise
- SUMO edge type strings (e.g. `highway.residential`) mapped to Tactics2D lane subtypes
- Speed limits converted from m/s to km/h
- Internal edges (`function="internal"`) skipped
- Junction `x`, `y`, `type`, and `shape` polygon parsed into `custom_tags`
- SUMO `<connection>` elements parsed and attached to their corresponding junctions via an `edge → to-junction` mapping
- Added junction shape auto-completion via convex hull of connected lane endpoints when `shape` is absent in the XML
- File header and imports aligned to project formatting requirements

### OpenDRIVE Parser (`tactics2d/map/parser/parse_xodr.py`)

- Restored `road_id` propagation into `custom_tags["xodr_road_id"]` on every `Lane`
- Suppressed numpy divide-by-zero warning in `_build_offset_polyline`
- Added docstrings to all five geometry samplers and `_make_roadline`
- Added `logging.warning` when a road `<type>` element is missing

### Rendering (`tactics2d/sensor/camera.py`, `tactics2d/renderer/matplotlib_config.py`)

- Junction shape polygons rendered beneath lane polygons (z-order 2), matching SUMO-GUI visual style
- Added colour and z-order entries for all SUMO junction types

## File Changes

| File | Type | Description |
|------|------|-------------|
| `tactics2d/map/element/junction.py` | Modified | Merge Connection into Junction; add custom_tags; fix mutable defaults |
| `tactics2d/map/element/__init__.py` | Modified | Remove Connection export |
| `tactics2d/map/parser/parse_net_xml.py` | New | Native SUMO `.net.xml` parser |
| `tactics2d/map/parser/parse_xodr.py` | Modified | Restore road_id chain; suppress warnings; add docstrings |
| `tactics2d/map/parser/__init__.py` | Modified | Register NetXMLParser |
| `tactics2d/sensor/camera.py` | Modified | Render junction shape polygons |
| `tactics2d/renderer/matplotlib_config.py` | Modified | Add junction colours and z-orders |
| `tests/test_map_parser.py` | Modified | Add net_xml test cases; add destroy() call |
| `tests/cases/NetXMLSamples/net.net.xml` | New | [SUMO official repo](https://github.com/eclipse-sumo/sumo/blob/main/tests/sumo/net.net.xml) |
| `tests/cases/NetXMLSamples/lefthand.net.xml` | New | [SUMO official repo](https://github.com/eclipse-sumo/sumo/blob/main/tests/sumo/lefthand.net.xml) |
| `tests/cases/NetXMLSamples/roundabout.net.xml` | New | Handcrafted roundabout topology test case |

## Test Results

`pytest tests/test_map_parser.py -m map_parser -k "xodr or net_xml"`

All 9 tests passed (6 xodr + 3 net_xml).

| net.net.xml | lefthand.net.xml | roundabout.net.xml |
|-------------|-----------------|-------------------|
| <img width="450" alt="net" src="https://github.com/user-attachments/assets/5d02b428-09fe-43f9-9dc5-64747445303d" /> | <img width="400" alt="lefthand" src="https://github.com/user-attachments/assets/9f0090c3-78b3-4393-95d2-ceb452207e0d" /> | <img width="350" alt="roundabout" src="https://github.com/user-attachments/assets/6d873c68-9573-48e4-8f95-7b75ebb0895b" /> |

Connection coverage across test cases:

| File | Lanes | Junctions | Connections |
|------|-------|-----------|-------------|
| net.net.xml | 20 | 9 | 32 |
| lefthand.net.xml | 16 | 13 | 24 |
| roundabout.net.xml | 24 | 8 | 22 |

## Engineering Notes

**ID handling**: The downstream renderer casts `Lane.id_` to `int`. To maintain compatibility while preserving SUMO's original string-based IDs (e.g. `"1fi_0"`), the parser uses an auto-incrementing integer for `id_` and stores the original in `custom_tags["sumo_id"]`.

**Connection attachment**: SUMO `<connection>` elements are top-level tags with no direct junction reference. The parser builds an `edge → to-junction` mapping during the edge pass and uses it to attach each connection to its corresponding junction after all junctions are loaded.

**custom_tags convention**: Format-specific fields are stored in `custom_tags` rather than adding format-specific slots to shared classes, consistent with the existing `Lane` pattern and keeping the data model extensible for future formats.

**Junction shape auto-completion**: When a junction's `shape` attribute is absent or empty in the XML, the parser computes a convex hull from the endpoints of all lanes flowing into that junction as a fallback, mirroring the behaviour of SUMO's netconvert.

## Checklist

- [x] Implement SUMO `.net.xml` parser with docstring examples for readthedocs
- [x] Register `NetXMLParser` in `__init__.py`
- [x] Junction geometry and type parsed into `custom_tags`
- [x] Connection lane links parsed and attached to junctions
- [x] Merge `Connection` into `Junction` per review feedback
- [x] Junction shape auto-completion and visualization
- [x] Header and imports aligned to formatting requirements
- [x] All tests passing (9/9)
- [ ] Junction `incLanes` / `intLanes` parsing (follow-up PR)
- [ ] Traffic light logic parsing (follow-up PR)

@SCP-CN-001 Ready for review. Thank you!