### PR TITLE
:bug: fix(env): expose vehicle size in lane_changing env info

### DIFF
--- a/homework/lane_changing.py
+++ b/homework/lane_changing.py
@@ -292,15 +292,20 @@ class LaneChangingEnv(gym.Env):
             )
 
             other_states = dict()
+            other_sizes = dict()
             for participant_id in participant_ids:
                 if participant_id == self.ego_id:
                     continue
-                other_states[participant_id] = self.participants[participant_id].get_state(step)
+                participant = self.participants[participant_id]
+                other_states[participant_id] = participant.get_state(step)
+                other_sizes[participant_id] = {"length": participant.length, "width": participant.width}
 
             infos = {
                 "status": self.status,
                 "ego_state": self.agent.current_state,
+                "ego_size": {"length": self.agent.length, "width": self.agent.width},
                 "other_states": other_states,
+                "other_sizes": other_sizes,
                 "centerlines": self.centerlines,
             }
 
@@ -396,16 +401,20 @@ class LaneChangingEnv(gym.Env):
             self.render_manager.bind(0, self.ego_id)
 
             other_states = dict()
+            other_sizes = dict()
             for participant_id, participant in self.participants.items():
                 if participant_id == self.ego_id:
                     continue
                 if participant.trajectory.has_state(self.compensation_step):
                     other_states[participant_id] = participant.get_state(self.compensation_step)
+                    other_sizes[participant_id] = {"length": participant.length, "width": participant.width}
 
             infos = {
                 "status": self.status,
                 "ego_state": ego_state,
+                "ego_size": {"length": self.agent.length, "width": self.agent.width},
                 "other_states": other_states,
+                "other_sizes": other_sizes,
                 "centerlines": self.centerlines,
             }
 


### PR DESCRIPTION
## Summary

Add `ego_size` and `other_sizes` to the `infos` dict returned by `LaneChangingEnv`, exposing real vehicle length and width from the highD dataset, so downstream models can use actual dimensions instead of hardcoded estimates.

## Motivation and Context

The existing `ego_state` and `other_states` in `infos` only carry kinematic states (position, heading, speed), not vehicle dimensions. Downstream models — for example a lane-changing or car-following controller — need vehicle length to compute safe inter-vehicle gaps, detect collisions, and avoid obstacles. Without access to real dimensions from the dataset, implementations are forced to guess or hardcode a single length for all vehicles, despite actual lengths ranging from roughly 3m (cars) to 19m (trucks). This PR adds vehicle size at the `infos` level rather than modifying the `State` class, keeping the change minimal and non-breaking.

## Changes (Mandatory)

- Add `ego_size` and `other_sizes` to `infos` in `_LaneChangingScenarioManager.update()`
- Mirror the same fields in `_LaneChangingScenarioManager.reset()`
- Build `other_sizes` in the same loop as `other_states` to guarantee participant ID alignment

## Testing (Mandatory)

- [ ] `pre-commit run --all-files` passed
- [ ] `pytest` passed
- [ ] Documentation style/format checked

Result summary (ignore if all checks passed):

Verified locally:
- `env.reset()` and `env.step()` both return `ego_size` and `other_sizes` in `infos`
- `other_sizes` keys match `other_states` keys exactly (verified across 100 steps)
- Vehicle sizes correctly distinguish cars (length 2.83m to 5.66m) from trucks (length 14.15m to 19.00m)
- Existing `AU7043_project_2_2026.py` runs without errors
