### PR TITLE
:recycle: refactor: Refine the structured road segment-based map generators and generation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Added
 
+- Refined structured road-segment generators, including fork/merge, ramp, intersection, two-way road, and related test coverage.
+- Updated generator rules and geometry helpers to improve roadline metadata handling, reference-line construction, and module connection consistency.
 - Added shared geometry and RoadLine utilities for road-segment map generation, including polyline sampling, cutting, offsetting, intersection extraction, curvature checks, and marking metadata support.
 - Added lane-marking foundations for map generation, including marking token specifications, MUTCD/GB rule tables, lane-change permissions, rendering metadata, and shared road module socket/result types.
 - Added a parser and corresponding tests, documentations for DriveInsightD dataset.

--- a/tactics2d/geometry/polyline.py
+++ b/tactics2d/geometry/polyline.py
@@ -3,8 +3,6 @@
 
 """Polyline geometry utilities."""
 
-from __future__ import annotations
-
 import numpy as np
 from shapely.geometry import LineString, Point
 

--- a/tactics2d/geometry/polyline.py
+++ b/tactics2d/geometry/polyline.py
@@ -3,6 +3,8 @@
 
 """Polyline geometry utilities."""
 
+from __future__ import annotations
+
 import numpy as np
 from shapely.geometry import LineString, Point
 

--- a/tactics2d/geometry/utils.py
+++ b/tactics2d/geometry/utils.py
@@ -9,7 +9,18 @@ from shapely.geometry import LinearRing, Polygon
 
 
 def as_point(point, name: str = "point") -> np.ndarray:
-    """Convert input to a validated 2D point array."""
+    """Convert input to a validated 2D point array.
+
+    Args:
+        point: Array-like with exactly 2 elements.
+        name: Field name used in the error message.
+
+    Returns:
+        A copy of the input as a ``(2,)`` float64 array.
+
+    Raises:
+        ValueError: If the resulting array does not have shape ``(2,)``.
+    """
     arr = np.asarray(point, dtype=float)
 
     if arr.shape != (2,):
@@ -19,26 +30,60 @@ def as_point(point, name: str = "point") -> np.ndarray:
 
 
 def heading_unit(heading: float) -> np.ndarray:
-    """Return the unit direction vector of a heading angle."""
+    """Return the unit direction vector of a heading angle.
+
+    Args:
+        heading: Heading angle in radians, measured counter-clockwise from the
+            positive x-axis.
+
+    Returns:
+        Unit vector ``[cos(heading), sin(heading)]`` with shape ``(2,)``.
+    """
     heading = float(heading)
     return np.array([np.cos(heading), np.sin(heading)], dtype=float)
 
 
 def normalize_angle(angle: float) -> float:
-    """Normalize an angle to the range [-pi, pi]."""
+    """Normalize an angle to the range ``[-pi, pi]``.
 
+    Args:
+        angle: Input angle in radians.
+
+    Returns:
+        Equivalent angle in ``[-pi, pi]``.
+    """
     return float(np.arctan2(np.sin(angle), np.cos(angle)))
 
 
 def euclidean_distance(a, b) -> float:
-    """Compute the Euclidean distance between two 2D points."""
+    """Compute the Euclidean distance between two 2D points.
 
+    Args:
+        a: First point as an array-like with at least 2 elements.
+        b: Second point as an array-like with at least 2 elements.
+
+    Returns:
+        Euclidean distance between the first two coordinates of ``a`` and ``b``.
+    """
     return float(np.linalg.norm(np.asarray(a, dtype=float)[:2] - np.asarray(b, dtype=float)[:2]))
 
 
 def oriented_box(x: float, y: float, heading: float, length: float, width: float) -> Polygon:
-    """Build an oriented rectangular polygon from center pose and dimensions."""
+    """Build an oriented rectangular polygon from a centre pose and dimensions.
 
+    Args:
+        x: Centre x-coordinate in metres.
+        y: Centre y-coordinate in metres.
+        heading: Orientation in radians, measured counter-clockwise from the
+            positive x-axis.
+        length: Box length along the heading direction in metres.  Values below
+            ``0.1`` are clamped to ``0.1``.
+        width: Box width perpendicular to the heading direction in metres.
+            Values below ``0.1`` are clamped to ``0.1``.
+
+    Returns:
+        Shapely :class:`~shapely.geometry.Polygon` representing the oriented box.
+    """
     length = max(float(length), 0.1)
     width = max(float(width), 0.1)
     bbox = LinearRing(

--- a/tactics2d/map/generator/road_segment/element_builder.py
+++ b/tactics2d/map/generator/road_segment/element_builder.py
@@ -268,7 +268,7 @@ def lane_ids(lanes: Iterable[Lane]) -> tuple[str, ...]:
 
 def build_pavement_junction(
     id_: str | int,
-    shape_points,
+    shape_points: list[tuple[float, float]],
     *,
     center: np.ndarray | None = None,
     junction_type: str,

--- a/tactics2d/map/generator/road_segment/fork_merge.py
+++ b/tactics2d/map/generator/road_segment/fork_merge.py
@@ -127,6 +127,23 @@ def _choose_branch_s(
 
     Returns:
         Arc-length position on the main centreline in metres.
+
+    Note:
+        The valid s-range is controlled by four module-level fraction constants
+        (expressed as a proportion of the total main-road length):
+
+        * ``_DIVERGE_LOWER`` = 0.15, ``_DIVERGE_UPPER`` = 0.82 — for fork, the
+          diverge point is constrained to the middle 67 % of the main road.
+          The 15 % head room prevents the opening from starting at the very
+          beginning of the segment; the 18 % tail room keeps the branch nose
+          visible before the exit socket.
+        * ``_MERGE_LOWER`` = 0.18, ``_MERGE_UPPER`` = 0.85 — the symmetric bounds
+          for merge; slightly tighter at the head end so the branch has room to
+          approach from upstream.
+        * ``_BRANCH_OFFSET_FACTOR`` = 0.45 — scales ``branch_length`` into a
+          longitudinal upstream/downstream offset so the inferred s-position
+          lands upstream (fork) or downstream (merge) of the branch socket's
+          nearest point on the main centreline, rather than right at it.
     """
     total = polyline_length(main_center)
     offset = max(float(taper_length), float(branch_length) * _BRANCH_OFFSET_FACTOR)

--- a/tactics2d/map/generator/road_segment/intersection.py
+++ b/tactics2d/map/generator/road_segment/intersection.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from tactics2d.geometry import heading_unit, normalize_angle, offset_polyline
 from tactics2d.map.element import Lane, RoadLine
+from tactics2d.map.generator.rules.lane_marking_rules import roadline_render_kwargs
 from tactics2d.map.generator.rules.module_types import RoadModuleResult, RoadPort
 
 from .element_builder import (
@@ -19,6 +20,7 @@ from .element_builder import (
     build_lane_from_boundaries,
     build_pavement_junction,
     build_roadline_from_points,
+    merge_marking_kwargs,
 )
 from .reference_line import bezier_connection, sample_centerline
 from .road_segment import RoadSegment
@@ -324,15 +326,24 @@ def _junction_shape_and_corners(
 def _intersection_mark_kwargs(tags: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return virtual RoadLine kwargs for an intersection connection boundary.
 
-    Internal intersection connection boundaries are needed by Lane.line_ids, but
-    they should not be rendered as visible lane markings inside the junction.
+    Internal intersection connection boundaries are required by ``Lane.line_ids``
+    but must not be rendered as visible markings inside the junction.  The kwargs
+    are built through :func:`roadline_render_kwargs` so that all standard metadata
+    fields (``marking_standard``, ``opendrive_*``, etc.) are populated consistently
+    with every other road-line builder.
+
+    Args:
+        tags: Optional extra tags merged into ``custom_tags`` with higher priority
+            than the built-in marking metadata.
+
+    Returns:
+        Dict with keys ``type_``, ``subtype``, ``color``, and ``custom_tags``
+        suitable for passing directly to :class:`~tactics2d.map.element.RoadLine`.
     """
-    custom_tags = {"marking_role": "virtual", "marking_token": "intersection_connection"}
-
+    extra = {"marking_token": "intersection_connection"}
     if tags is not None:
-        custom_tags.update(tags)
-
-    return {"type_": "virtual", "subtype": "virtual", "color": "white", "custom_tags": custom_tags}
+        extra.update(tags)
+    return merge_marking_kwargs(roadline_render_kwargs("virtual"), extra)
 
 
 def _intersection_build(

--- a/tactics2d/map/generator/road_segment/ramp.py
+++ b/tactics2d/map/generator/road_segment/ramp.py
@@ -20,7 +20,7 @@ from tactics2d.geometry import (
 )
 from tactics2d.map.element import Area, Lane, LaneRelationship, RoadLine
 from tactics2d.map.generator.rules.lane_marking_rules import (
-    one_way_mark,
+    one_way_boundary_token,
     ramp_mark,
     roadline_render_kwargs,
     two_way_backward,
@@ -38,6 +38,7 @@ from tactics2d.map.generator.rules.module_types import (
 
 from .element_builder import (
     add_ordered_lane_neighbors,
+    boundary_offset,
     build_lane_from_boundaries,
     build_roadline_from_points,
     build_segmented_roadline,
@@ -135,27 +136,25 @@ def _build_freeway_main_road(
     lanes: list[Lane] = []
     roadlines: list[RoadLine] = []
 
-    total_half_width = lane_num * lane_width / 2.0
-    boundary_offsets = [total_half_width - i * lane_width for i in range(lane_num + 1)]
-    boundary_pts = [offset_polyline(center_pts, offset) for offset in boundary_offsets]
+    boundary_num = lane_num + 1
+    boundary_pts = [
+        offset_polyline(center_pts, boundary_offset(i, lane_num, lane_width))
+        for i in range(boundary_num)
+    ]
     boundary_line_ids: list[list[str]] = []
 
     for boundary_idx, pts in enumerate(boundary_pts):
         is_left_edge = boundary_idx == 0
         is_right_edge = boundary_idx == lane_num
 
+        marking_kwargs = roadline_render_kwargs(one_way_boundary_token(boundary_idx, boundary_num))
         if is_left_edge:
-            marking_kwargs = roadline_render_kwargs(one_way_mark(0, lane_num, "left"))
             side = "left"
             gap = edge_gap if ramp_side == "left" else None
         elif is_right_edge:
-            marking_kwargs = roadline_render_kwargs(one_way_mark(lane_num - 1, lane_num, "right"))
             side = "right"
             gap = edge_gap if ramp_side == "right" else None
         else:
-            marking_kwargs = roadline_render_kwargs(
-                one_way_mark(boundary_idx - 1, lane_num, "right")
-            )
             side = "interior"
             gap = None
 
@@ -688,11 +687,11 @@ def _build_ramp(
 
     if main_road_type == "freeway":
         total_half_width = lane_num * lane_w / 2.0
-        boundary_offset = -total_half_width if ramp_side == "right" else total_half_width
+        ramp_edge_offset = -total_half_width if ramp_side == "right" else total_half_width
     else:
-        boundary_offset = -lane_num * lane_w
+        ramp_edge_offset = -lane_num * lane_w
 
-    boundary_preview = offset_polyline(center_pts, boundary_offset)
+    boundary_preview = offset_polyline(center_pts, ramp_edge_offset)
     boundary_length = polyline_length(boundary_preview)
     ramp_s = nearest_s(boundary_preview, as_point(ramp_port.point))
 
@@ -892,7 +891,7 @@ def _build_ramp(
         )
 
     return RoadModuleResult(
-        lanes=lanes, roadlines=roadlines, ports=ports, id_counter=id_counter, junctions=areas
+        lanes=lanes, roadlines=roadlines, ports=ports, id_counter=id_counter, areas=areas
     )
 
 

--- a/tactics2d/map/generator/road_segment/reference_line.py
+++ b/tactics2d/map/generator/road_segment/reference_line.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import numpy as np
 
 from tactics2d.geometry import as_point, heading_unit, normalize_angle
-from tactics2d.geometry.polyline import polyline_end_pose
 from tactics2d.interpolator import Bezier
 from tactics2d.interpolator.spiral import Spiral
 
@@ -66,30 +65,6 @@ def sample_centerline(
         gamma=0.0,
         n_interpolation=n_interpolation,
     )
-
-
-def get_exit(pts: np.ndarray, heading: float, curvature: float) -> tuple[np.ndarray, float]:
-    """Return exit point and heading of a sampled centre line.
-
-    Args:
-        pts: Sampled centre-line points with shape ``(N, 2)``.
-        heading: Input heading in radians.
-        curvature: Centre-line curvature.
-
-    Returns:
-        A tuple ``(exit_point, exit_heading)``.
-    """
-    pts = np.asarray(pts, dtype=float)
-
-    if pts.ndim != 2 or pts.shape[1] != 2:
-        raise ValueError(f"pts must have shape (N, 2), got {pts.shape}.")
-    if len(pts) < 2:
-        raise ValueError("pts must contain at least two points.")
-
-    if abs(float(curvature)) < 1e-9:
-        return pts[-1].copy(), float(heading)
-
-    return polyline_end_pose(pts)
 
 
 def arc_pts(
@@ -239,26 +214,3 @@ def fit_reference_line(
         return p0 + np.outer(s, chord / length)
 
     return bezier_connection(p0=p0, h0=start_heading, p3=p1, h3=end_heading, step_size=step_size)
-
-
-def hermite_cubic_width(s_local: np.ndarray, length: float, target_width: float) -> np.ndarray:
-    """Return a zero-slope cubic width transition (smoothstep Hermite cubic).
-
-    Args:
-        s_local: Local arc-length coordinates.
-        length: Transition length. Must be positive.
-        target_width: Target width or width delta.
-
-    Returns:
-        Width values with the same shape as ``s_local``.
-    """
-    length = float(length)
-    target_width = float(target_width)
-
-    if length <= 0.0:
-        raise ValueError("length must be positive.")
-
-    s_local = np.asarray(s_local, dtype=float)
-    t = np.clip(s_local / length, 0.0, 1.0)
-
-    return target_width * (3.0 * t**2 - 2.0 * t**3)

--- a/tactics2d/map/generator/road_segment/road_segment.py
+++ b/tactics2d/map/generator/road_segment/road_segment.py
@@ -39,6 +39,13 @@ class RoadSegment(ABC):
                 each subclass documents which keys are accepted.
 
         Returns:
-            A :class:`RoadModuleResult` containing lanes, roadlines, ports,
-            interfaces, quality statistics, and the next available id counter.
+            A :class:`RoadModuleResult` containing lanes, roadlines, junctions,
+            named ports, and the next available id counter.
+
+        Note:
+            Centre-based generators (:class:`~tactics2d.map.generator.road_segment.Intersection`
+            and :class:`~tactics2d.map.generator.road_segment.Roundabout`) override this
+            signature with ``(center, arms, *, id_offset)`` because their primary
+            inputs are a world-space centre point and a list of arm descriptors rather
+            than a flat sequence of :class:`RoadPort` sockets.
         """

--- a/tactics2d/map/generator/road_segment/two_way.py
+++ b/tactics2d/map/generator/road_segment/two_way.py
@@ -111,7 +111,6 @@ class TwoWay(RoadSegment):
         id_counter += 1
         roadlines.append(center_roadline)
 
-        # --- Forward direction: N+1 shared boundary roadlines, N lanes ---
         forward_boundary_pts: list[np.ndarray] = [center_pts]
         forward_boundary_rls: list[RoadLine] = [center_roadline]
 
@@ -147,9 +146,6 @@ class TwoWay(RoadSegment):
 
         add_ordered_lane_neighbors(forward_lanes)
 
-        # --- Backward direction: N+1 shared boundary roadlines, N lanes ---
-        # Polylines are reversed so each backward lane drives end→start.
-        # boundary[0] reuses center_roadline; boundary[1..N] are new at increasing offsets.
         backward_boundary_pts: list[np.ndarray] = [center_pts[::-1]]
         backward_boundary_rls: list[RoadLine] = [center_roadline]
 

--- a/tactics2d/map/generator/rules/__init__.py
+++ b/tactics2d/map/generator/rules/__init__.py
@@ -7,7 +7,6 @@ from .lane_marking_config import GB_RULES, MARKING_SPECS, MUTCD_RULES, STANDARD_
 from .lane_marking_rules import (
     get_standard,
     one_way_boundary_token,
-    one_way_mark,
     ramp_mark,
     roadline_render_kwargs,
     set_standard,
@@ -33,7 +32,6 @@ __all__ = [
     "set_standard",
     "roadline_render_kwargs",
     "one_way_boundary_token",
-    "one_way_mark",
     "ramp_mark",
     "two_way_backward",
     "two_way_centerline",

--- a/tactics2d/map/generator/rules/lane_marking_rules.py
+++ b/tactics2d/map/generator/rules/lane_marking_rules.py
@@ -204,24 +204,6 @@ def two_way_backward(
     return t["tw_backward_interior"]
 
 
-def one_way_mark(
-    lane_index: int,
-    total_lanes: int,
-    side: Literal["left", "right"],
-    *,
-    standard: str | None = None,
-) -> str:
-    """Return the marking token for a lane boundary in a one-way road."""
-    t = _table(standard)
-
-    if side == "left" and lane_index == 0:
-        return t["ow_left_edge"]
-    if side == "right" and lane_index == total_lanes - 1:
-        return t["ow_right_edge"]
-
-    return t["ow_interior"]
-
-
 def ramp_mark(
     role: Literal[
         "aux_left",
@@ -269,10 +251,10 @@ def one_way_boundary_token(boundary_index: int, boundary_num: int) -> str:
     Returns:
         Marking token string.
     """
-    lane_num = boundary_num - 1
+    t = _table(None)
 
     if boundary_index == 0:
-        return one_way_mark(0, lane_num, "left")
+        return t["ow_left_edge"]
     if boundary_index == boundary_num - 1:
-        return one_way_mark(lane_num - 1, lane_num, "right")
-    return one_way_mark(boundary_index - 1, lane_num, "right")
+        return t["ow_right_edge"]
+    return t["ow_interior"]

--- a/tactics2d/map/generator/rules/module_types.py
+++ b/tactics2d/map/generator/rules/module_types.py
@@ -98,14 +98,17 @@ class RoadModuleResult:
         ports: Named RoadPort dictionary, keyed by logical port name.
         id_counter: Next available element id.  Pass as ``id_offset`` to the
             next generator to prevent id collisions across modules.
-        junctions: Generated Junction (or Area) objects.
+        junctions: Generated Junction objects, e.g. intersection pavement polygons
+            and roundabout rings.
+        areas: Generated Area objects, e.g. gore islands and surface fill polygons.
     """
 
     lanes: list[Lane]
     roadlines: list[RoadLine]
     ports: dict[str, RoadPort]
     id_counter: int
-    junctions: list[Junction | Area] = field(default_factory=list)
+    junctions: list[Junction] = field(default_factory=list)
+    areas: list[Area] = field(default_factory=list)
 
 
 def make_port(

--- a/tactics2d/renderer/matplotlib_renderer.py
+++ b/tactics2d/renderer/matplotlib_renderer.py
@@ -232,86 +232,64 @@ class MatplotlibRenderer:
         self.ylim = (new_y_min, new_y_max)
 
     def _resolve_style(self, color_key: str, type_key) -> tuple:
-        """Resolve style keys to concrete color value and z-order.
+        if isinstance(color_key, str) and color_key.lower() in ("none", "transparent"):
+            if isinstance(type_key, (int, float)):
+                z_order = type_key
+            elif isinstance(type_key, str) and type_key in DEFAULT_ORDER:
+                z_order = DEFAULT_ORDER[type_key]
+            else:
+                z_order = 1
+            return "none", z_order
 
-        Args:
-            color_key: Color key (could be color name like 'white' or type key like 'vehicle')
-            type_key: Element type key (string) or numeric z-order (int/float)
-
-        Returns:
-            tuple: (color_value, z_order)
-        """
-        # Resolve color
         if color_key in COLOR_PALETTE:
-            # Direct color name like 'white', 'red', etc.
             color = COLOR_PALETTE[color_key]
         elif color_key in DEFAULT_COLOR:
-            # Type-based key like 'vehicle', 'lane', etc.
             color_value = DEFAULT_COLOR[color_key]
-            # The value might be a color name or hex code
-            if color_value in COLOR_PALETTE:
-                color = COLOR_PALETTE[color_value]
-            else:
-                color = color_value  # Assume it's already a hex code or valid color
+            color = COLOR_PALETTE.get(color_value, color_value)
         elif isinstance(color_key, str) and color_key.startswith("#"):
-            # Hex color code like "#FF0000"
             color = color_key
         elif type_key in DEFAULT_COLOR:
-            # Type-based key like 'vehicle', 'lane', etc.
             color_value = DEFAULT_COLOR[type_key]
-            # The value might be a color name or hex code
-            if color_value in COLOR_PALETTE:
-                color = COLOR_PALETTE[color_value]
-            else:
-                color = color_value  # Assume it's already a hex code or valid color
+            color = COLOR_PALETTE.get(color_value, color_value)
         else:
-            # Fallback to default color
             color = COLOR_PALETTE["black"]
 
-        # Resolve z-order from type key
         if isinstance(type_key, (int, float)):
-            # Already a numeric value
             z_order = type_key
         elif isinstance(type_key, str) and type_key in DEFAULT_ORDER:
-            # String key, look up in DEFAULT_ORDER
             z_order = DEFAULT_ORDER[type_key]
+        elif isinstance(color_key, str) and color_key in DEFAULT_ORDER:
+            z_order = DEFAULT_ORDER[color_key]
         else:
-            # Fallback: try to use color_key as type key
-            if isinstance(color_key, str) and color_key in DEFAULT_ORDER:
-                z_order = DEFAULT_ORDER[color_key]
-            else:
-                # Fallback to default z-order
-                z_order = 1
+            z_order = 1
 
         return color, z_order
 
     def _create_polygon(self, element: Dict[str, Any]) -> Optional[Polygon]:
-        """Create a matplotlib Polygon from element data.
-
-        Args:
-            element (Dict[str, Any]): Polygon element data with keys:
-                'id' (str): Element identifier.
-                'geometry' (List[Tuple[float, float]]): Polygon vertices.
-                'color' (str): Color key (color name or type key).
-                'line_width' (float): Border line width.
-                'order' (str): Z-order key (type key).
-
-        Returns:
-            Optional[Polygon]: Polygon object if geometry has at least 3 points,
-                otherwise None.
-        """
         if len(element["geometry"]) < 3:
             logging.warning(f"Polygon with id {element['id']} has less than 3 points, skipping.")
             return None
 
-        # Resolve color and z-order from style keys
         color, z_order = self._resolve_style(element["color"], element.get("type"))
+
+        if color == "none":
+            return Polygon(
+                xy=element["geometry"],
+                closed=True,
+                facecolor="none",
+                edgecolor="none",
+                linewidth=0,
+                antialiased=False,
+                zorder=z_order,
+            )
 
         return Polygon(
             xy=element["geometry"],
             closed=True,
             facecolor=color,
-            linewidth=element["line_width"],
+            edgecolor=color,
+            linewidth=0,
+            antialiased=False,
             zorder=z_order,
         )
 

--- a/tactics2d/sensor/camera.py
+++ b/tactics2d/sensor/camera.py
@@ -5,7 +5,7 @@
 
 
 import time
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 from shapely.geometry import Point, Polygon
@@ -20,12 +20,12 @@ class BEVCamera(SensorBase):
     """This class defines the render paradigm of a BEV camera.
 
     Attributes:
-        id_ (int): The unique identifier of the sensor. This attribute is **read-only** once the instance is initialized.
-        map_ (Map): The map that the sensor is attached to. This attribute is **read-only** once the instance is initialized.
+        id_ (int): The unique identifier of the sensor. This attribute is read-only once the instance is initialized.
+        map_ (Map): The map that the sensor is attached to. This attribute is read-only once the instance is initialized.
         perception_range (Union[float, Tuple[float]]): The distance from the sensor to its maximum detection range in (left, right, front, back). When this value is undefined, the sensor is assumed to detect the whole map. Defaults to None.
         position (Point): The position of the sensor in the global 2D coordinate system.
-        bind_id (Any): The unique identifier of object that the sensor is bound to. This attribute is **read-only** and can only be set using the `bind_with` method.
-        is_bound (bool): Whether the sensor is bound to an object. This attribute is **read-only** once the instance is initialized.
+        bind_id (Any): The unique identifier of object that the sensor is bound to. This attribute is read-only and can only be set using the bind_with method.
+        is_bound (bool): Whether the sensor is bound to an object. This attribute is read-only once the instance is initialized.
     """
 
     def __init__(self, id_: int, map_: Map, perception_range: Union[float, Tuple[float]] = None):
@@ -45,32 +45,32 @@ class BEVCamera(SensorBase):
             geometry: Shapely geometry object to check.
 
         Returns:
-            True if geometry is within perception range or sensor has no position,
-            False otherwise.
+            True if geometry is within perception range or sensor has no position, False otherwise.
         """
         if self._position is None:
             return True
 
         return geometry.distance(self._position) <= self.max_perception_distance * 1.5
 
+    def _is_pavement_junction(self, junction: Junction) -> bool:
+        """Return whether a junction is a generated road-surface fill polygon."""
+        return junction.custom_tags.get("type") == "road"
+
     def _get_type(self, element: Any) -> str:
         """Get the type string for a map or participant element.
 
         Args:
-            element: Map element (Area, Junction, Lane, RoadLine) or participant element.
+            element: Map element or participant element.
 
         Returns:
             String type identifier for the element.
         """
+        if isinstance(element, Junction):
+            return element.custom_tags.get("type") or "junction"
         if hasattr(element, "subtype") and element.subtype:
             return element.subtype
         elif hasattr(element, "type_") and element.type_:
             return element.type_
-        elif isinstance(element, Junction):
-            # Use the SUMO junction type stored in custom_tags when available,
-            # otherwise fall back to the generic "junction" key so that
-            # matplotlib_config.DEFAULT_COLOR["junction"] is resolved.
-            return element.custom_tags.get("type") or "junction"
         elif isinstance(element, Area):
             return "area"
         elif isinstance(element, Lane):
@@ -86,63 +86,72 @@ class BEVCamera(SensorBase):
 
         return "default"
 
+    def _make_junction_element(
+        self, junction: Junction
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[int]]:
+        """Convert a Junction into a renderer element."""
+        shape_pts = junction.custom_tags.get("shape", [])
+        if len(shape_pts) < 3:
+            return None, None
+
+        try:
+            junction_polygon = Polygon(shape_pts)
+        except Exception:
+            return None, None
+
+        if not self._in_perception_range(junction_polygon):
+            return None, None
+
+        if self._is_pavement_junction(junction):
+            buffered_polygon = junction_polygon.buffer(0.05)
+            if buffered_polygon.is_empty or buffered_polygon.geom_type != "Polygon":
+                buffered_polygon = junction_polygon
+
+            element_color = "road"
+            element_type: str | float = 3.1
+            element_geometry = list(buffered_polygon.exterior.coords)
+        else:
+            element_color = self._get_type(junction)
+            element_type = element_color
+            element_geometry = list(junction_polygon.exterior.coords)
+
+        element_id = int(2e6 + int(junction.id_))
+
+        return (
+            {
+                "id": element_id,
+                "shape": "polygon",
+                "geometry": element_geometry,
+                "color": element_color,
+                "type": element_type,
+                "line_width": 0,
+            },
+            element_id,
+        )
+
     def _get_map_elements(self, prev_road_id_set: Set[int]) -> Tuple[Dict, Set[int]]:
         """Get map elements within perception range for rendering.
 
-        Processes junctions, areas, lanes, and roadlines in z-order (lowest first)
-        so that junction fill polygons are drawn beneath lane polygons and road
-        markings, matching SUMO-GUI's default visual style.
-
-        Args:
-            prev_road_id_set: Set of road IDs from previous frame.
-
-        Returns:
-            Tuple of (map_data, road_id_set) where map_data contains road elements
-            to remove and create, and road_id_set is the set of road IDs in current frame.
+        Render order is areas, lanes, junctions, then roadlines.
+        Ordinary junctions stay below lanes through their z-order.
+        Pavement-fill junctions use type 3.1 and are inserted after lanes to cover lane end-cap seams.
         """
         road_id_list = []
         road_element_list = []
         white = "white"
 
-        # Process junctions (z-order 2, beneath lanes)
-        for junction in self._map.junctions.values():
-            shape_pts = junction.custom_tags.get("shape", [])
-            if len(shape_pts) < 3:
-                continue
-
-            try:
-                junction_polygon = Polygon(shape_pts)
-            except Exception:
-                continue
-
-            if not self._in_perception_range(junction_polygon):
-                continue
-
-            junc_type = self._get_type(junction)
-            element_id = int(2e6 + int(junction.id_))
-
-            road_element_list.append(
-                {
-                    "id": element_id,
-                    "shape": "polygon",
-                    "geometry": list(junction_polygon.exterior.coords),
-                    "color": junc_type,
-                    "type": junc_type,
-                    "line_width": 0,
-                }
-            )
-            road_id_list.append(element_id)
-
-        # Process areas (obstacles, etc.)
         for area in self._map.areas.values():
+            if area.geometry is None:
+                continue
             if not self._in_perception_range(area.geometry):
                 continue
 
             interiors = list(area.geometry.interiors)
+            area_id = int(1e6 + int(area.id_))
 
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(area.id_)),
+                    "id": area_id,
                     "shape": "polygon",
                     "geometry": list(area.geometry.exterior.coords),
                     "color": area.color,
@@ -150,12 +159,14 @@ class BEVCamera(SensorBase):
                     "line_width": 0,
                 }
             )
-            road_id_list.append(int(1e6 + int(area.id_)))
+            road_id_list.append(area_id)
 
             for i, interior in enumerate(interiors):
+                hole_id = int(1e6 + int(area.id_) + i * 1e5)
+
                 road_element_list.append(
                     {
-                        "id": int(1e6 + int(area.id_) + i * 1e5),
+                        "id": hole_id,
                         "shape": "polygon",
                         "geometry": list(interior.coords),
                         "color": white,
@@ -163,16 +174,19 @@ class BEVCamera(SensorBase):
                         "line_width": 0,
                     }
                 )
-                road_id_list.append(int(1e6 + int(area.id_) + i * 1e5))
+                road_id_list.append(hole_id)
 
-        # Process lanes
         for lane in self._map.lanes.values():
+            if lane.geometry is None:
+                continue
             if not self._in_perception_range(lane.geometry):
                 continue
 
+            lane_id = int(1e6 + int(lane.id_))
+
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(lane.id_)),
+                    "id": lane_id,
                     "shape": "polygon",
                     "geometry": list(lane.geometry.coords),
                     "color": lane.color,
@@ -180,10 +194,20 @@ class BEVCamera(SensorBase):
                     "line_width": 0,
                 }
             )
-            road_id_list.append(int(1e6 + int(lane.id_)))
+            road_id_list.append(lane_id)
 
-        # Process roadlines (skip virtual lines)
+        for junction in self._map.junctions.values():
+            junction_element, junction_id = self._make_junction_element(junction)
+
+            if junction_element is None or junction_id is None:
+                continue
+
+            road_element_list.append(junction_element)
+            road_id_list.append(junction_id)
+
         for roadline in self._map.roadlines.values():
+            if roadline.geometry is None:
+                continue
             if roadline.type_ == "virtual" or not self._in_perception_range(roadline.geometry):
                 continue
 
@@ -194,10 +218,11 @@ class BEVCamera(SensorBase):
                 line_width = 2
 
             line_color = white if roadline.color is None else roadline.color
+            roadline_id = int(1e6 + int(roadline.id_))
 
             road_element_list.append(
                 {
-                    "id": int(1e6 + int(roadline.id_)),
+                    "id": roadline_id,
                     "shape": "line",
                     "geometry": list(roadline.geometry.coords),
                     "color": line_color,
@@ -206,7 +231,7 @@ class BEVCamera(SensorBase):
                     "line_width": line_width,
                 }
             )
-            road_id_list.append(int(1e6 + int(roadline.id_)))
+            road_id_list.append(roadline_id)
 
         road_id_set = set(road_id_list)
         road_id_to_create = road_id_set - prev_road_id_set
@@ -240,9 +265,7 @@ class BEVCamera(SensorBase):
             prev_participant_id_set: Set of participant IDs from previous frame.
 
         Returns:
-            Tuple of (participant_data, participant_id_set) where participant_data contains
-            participant elements to remove and create, and participant_id_set is the set of
-            participant IDs in current frame.
+            Tuple of participant_data and participant_id_set.
         """
         participant_id_list = []
         participant_list = []
@@ -340,24 +363,7 @@ class BEVCamera(SensorBase):
         position: Point = None,
         heading: float = None,
     ) -> Tuple[Dict, Set, Set]:
-        """This function is used to update the camera's position and obtain the geometry data under specific rendering paradigm.
-
-        Args:
-            frame (int): The frame of the observation.
-            participants (Dict): The participants in the scenario.
-            participant_ids (List): The list of participant IDs to be rendered.
-            prev_road_id_set (Set, optional): The set of road IDs that were rendered in the previous frame.
-                Defaults to None.
-            prev_participant_id_set (Set, optional): The set of participant IDs that were rendered in the previous frame.
-                Defaults to None.
-            position (Point, optional): The position of the camera. Defaults to None.
-            heading (float, optional): The heading of the camera in radians. Defaults to None.
-
-        Returns:
-            geometry_data (Dict): The geometry data to be rendered in unified format.
-            road_id_set (Set): The set of road IDs that were rendered in the current frame.
-            participant_id_set (Set): The set of participant IDs that were rendered in the current frame.
-        """
+        """Update the camera and return geometry data."""
         self._set_position_heading(position, heading)
 
         participant_ids, prev_road_id_set, prev_participant_id_set = self._setup_update_parameters(

--- a/tests/test_map_generator.py
+++ b/tests/test_map_generator.py
@@ -55,7 +55,7 @@ def _render(map_: Map, save_to: str) -> None:
 
 def _assert_result_element_ids_unique(result: RoadModuleResult) -> None:
     """Assert that one module result has no duplicate element ids."""
-    elements = [*result.lanes, *result.roadlines, *getattr(result, "junctions", [])]
+    elements = [*result.lanes, *result.roadlines, *result.junctions, *result.areas]
     ids = [element.id_ for element in elements]
     assert len(ids) == len(set(ids))
 
@@ -79,8 +79,10 @@ def _add_result(map_: Map, result: RoadModuleResult) -> None:
         map_.add_lane(lane)
     for roadline in result.roadlines:
         map_.add_roadline(roadline)
-    for junction in getattr(result, "junctions", []):
+    for junction in result.junctions:
         map_.add_junction(junction)
+    for area in result.areas:
+        map_.add_area(area)
 
 
 def _make_port(
@@ -202,8 +204,9 @@ def test_one_way_curved():
     _add_result(map_, result)
     _render(map_, "./tests/runtime/one_way_curved.png")
     assert len(map_.lanes) == 2
-    assert isinstance(result.ports["exit"].point, np.ndarray)
-    assert isinstance(result.ports["exit"].heading, float)
+    assert result.ports["exit"].lane_num == 2
+    assert result.ports["exit"].heading == pytest.approx(0.65)
+    np.testing.assert_allclose(result.ports["exit"].point, [30.0, 15.0], atol=1e-9)
 
 
 @pytest.mark.map_generator
@@ -579,8 +582,8 @@ def test_ramp_no_id_collision() -> None:
         id_offset=r1.id_counter,
     )
     assert r2.id_counter > r1.id_counter
-    ids1 = {e.id_ for e in [*r1.lanes, *r1.roadlines, *r1.junctions]}
-    ids2 = {e.id_ for e in [*r2.lanes, *r2.roadlines, *r2.junctions]}
+    ids1 = {e.id_ for e in [*r1.lanes, *r1.roadlines, *r1.junctions, *r1.areas]}
+    ids2 = {e.id_ for e in [*r2.lanes, *r2.roadlines, *r2.junctions, *r2.areas]}
     assert len(ids1 & ids2) == 0
 
 


### PR DESCRIPTION
## Summary

This PR refines the structured road-segment map generator implementation.

It updates geometry helpers, generator rules, road-segment construction modules, renderer/camera support, and map-generator tests. The main goal is to make the generated road segments more consistent in geometry construction, RoadLine metadata handling, module connection behavior, and test coverage.

## Changed Files

| File | Status | Purpose |
|---|---|---|
| `CHANGELOG.md` | Modified | Records the road-segment generator refinement updates. |
| `tactics2d/geometry/polyline.py` | Modified | Refines reusable polyline utilities used by road-segment generation. |
| `tactics2d/geometry/utils.py` | Modified | Updates shared geometry helpers such as point validation, heading vectors, angle normalization, distance calculation, and oriented-box construction. |
| `tactics2d/map/generator/road_segment/road_segment.py` | Modified | Refines the abstract `RoadSegment` base class and build interface documentation. |
| `tactics2d/map/generator/road_segment/reference_line.py` | Modified | Updates reference-line sampling and connection helpers used by road-segment modules. |
| `tactics2d/map/generator/road_segment/element_builder.py` | Modified | Refines shared builders for lanes, RoadLines, pavement junctions, lane relationships, segmented roadlines, and junction arm ports. |
| `tactics2d/map/generator/road_segment/fork_merge.py` | Modified | Refines fork/merge generation logic and related geometry handling. |
| `tactics2d/map/generator/road_segment/intersection.py` | Modified | Refines intersection generation logic, arm handling, and junction output consistency. |
| `tactics2d/map/generator/road_segment/ramp.py` | Modified | Refines entrance/exit ramp generation and roadline connection behavior. |
| `tactics2d/map/generator/road_segment/two_way.py` | Modified | Refines two-way road generation behavior and lane/roadline construction. |
| `tactics2d/map/generator/rules/__init__.py` | Modified | Updates package-level exports for generator rule utilities. |
| `tactics2d/map/generator/rules/lane_marking_rules.py` | Modified | Refines lane-marking rule helpers and removes unnecessary implementation-level export handling. |
| `tactics2d/map/generator/rules/module_types.py` | Modified | Refines shared road-module types such as `RoadPort` and `RoadModuleResult`. |
| `tactics2d/sensor/camera.py` | Modified | Updates BEV camera map-element extraction to support generated road-segment visualization. |
| `tactics2d/renderer/matplotlib_renderer.py` | Modified | Updates matplotlib rendering behavior for generated map elements. |
| `tests/test_map_generator.py` | Modified | Updates tests for structured road-segment generation and related validation/rendering helpers. |

## Main Changes

- Refined shared geometry utilities used by map generation.
- Refined `RoadSegment` base interface and reference-line construction helpers.
- Centralized repeated lane, RoadLine, junction, and port construction logic in `element_builder.py`.
- Refined concrete road-segment modules including fork/merge, ramp, intersection, and two-way road generation.
- Updated generator rule helpers and shared module types.
- Updated camera and matplotlib renderer support for generated map elements.
- Updated map-generator tests and helper checks.

## Design Review Notes

### `rules` and `traffic`

`map/generator/rules/` and `traffic/` are responsible for different layers.

`map/generator/rules/` stores static generation-time rules and shared generator types, including lane-marking specifications, MUTCD/GB marking mappings, `RoadPort`, and `RoadModuleResult`. These are used by procedural road-segment generators when constructing map elements.

`traffic/` is runtime traffic logic, such as event detection, scenario state management, and traffic participant behavior.

Therefore, the current `rules` package belongs under `map/generator/`, not `traffic/`.

### `__all__` cleanup

The previous extra `__all__` definition in `lane_marking_rules.py` has been removed.

Public exports are now centralized in `rules/__init__.py`, keeping the implementation file simpler and avoiding duplicate export lists.

### Test helper functions

The helper functions in `tests/test_map_generator.py` are test-local helpers, not duplicated library logic.

Functions such as `_render`, `_make_port`, and `_assert_*` are only used to set up test cases, conditionally render debug outputs, and assert generated map structure. They are not duplicated generator functions.

### Folder naming

The current folder naming is consistent with the existing project style.

Core packages such as `element`, `converter`, `parser`, and `renderer` follow the repository convention. `utils` remains plural because that is the common Python naming convention for utility collections.

### Redundancy and simplification

The current code has been simplified where it affects maintainability:

- removed unnecessary `__all__` from implementation files;
- kept generator rules separate from runtime traffic logic;
- kept test helpers local where they only serve testing setup/assertion needs;
- centralized repeated RoadLine, Lane, Junction, and port construction logic in shared builder helpers;
- kept road-segment geometry steps explicit where early over-abstraction would make review and debugging harder.

The remaining repeated-looking parts are mostly data definitions, explicit geometry-construction steps, or test assertions. They are kept explicit for readability and reviewability.

## Validation

- Ran pre-commit on the modified files.
- Updated `tests/test_map_generator.py` to cover the refined road-segment generation behavior.