### PR TITLE
:memo: docs(display): fix browser frontend tutorial and env render_mode docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ### Fixed
 
+- Fixed browser frontend tutorial incorrectly stating `fastapi`/`uvicorn` are optional dependencies (they are core dependencies installed with the package), and added missing `ParticipantElement`/`CameraMetadata` imports in the display backend example.
+- Fixed `render_mode` docstrings in `ParkingEnv` and `RacingEnv` missing the supported `browser` and `matplotlib` modes.
+- Synchronized the Chinese browser frontend tutorial with the English version by adding the missing "Unified Display Backend" section (factory usage, environment integration, render mode table, recording output).
 - Fixed `NetXMLParser._get_lane_subtype` incorrectly declared as `@staticmethod` with a `self` parameter, causing all lane parsing to fail silently.
 - Fixed `NetXMLParser._offset_line` referencing undefined normal vector variables when consecutive points have zero distance.
 - Fixed `NetXMLParser` not reading the lane element's `width` attribute, falling back to inaccurate heuristic estimation.

--- a/docs/i18n/zh/tutorial/browser_frontend.md
+++ b/docs/i18n/zh/tutorial/browser_frontend.md
@@ -128,3 +128,106 @@ renderer.send_frame([sensor], frame=frame)
 - 进入实时模式时，前端会保留最近一次实时快照；仿真运行中刷新浏览器不会清空当前场景。
 - 如果浏览器只显示车辆、没有道路，先检查源地图 payload。部分数据集在轨迹中提供
   `Lane_ID`，但并没有可渲染为地图的车道几何。
+
+## 统一显示后端
+
+Tactics2D 提供统一的 `DisplayBackend` 接口，把所有渲染方式（pygame、浏览器、
+matplotlib、null）封装在同一套 API 后面。新代码推荐使用这种方式渲染场景。
+
+### 使用工厂函数
+
+```python
+from tactics2d.display import (
+    CameraMetadata,
+    ParticipantElement,
+    SceneSnapshot,
+    create_display_backend,
+)
+
+# 创建浏览器后端（需要时自动启动前端服务）
+backend = create_display_backend("browser")
+
+# 构造一帧快照
+snapshot = SceneSnapshot(
+    frame=0,
+    participants={
+        1: ParticipantElement(
+            id_=1, shape="polygon",
+            geometry=[[-2,-1],[2,-1],[2,1],[-2,1]],
+            position=(0, 0), rotation=0.0, type_="vehicle",
+        ),
+    },
+    cameras=[CameraMetadata(id_="cam0", position=(0,0), yaw=0.0, perception_range=50)],
+)
+
+# 每帧渲染
+for frame in range(120):
+    snapshot.frame = frame
+    snapshot.participants[1].position = (frame * 0.2, 0.0)
+    backend.render(snapshot)
+
+backend.close()
+```
+
+### 与环境集成
+
+创建环境时设置 `render_mode="browser"`，环境会自动创建浏览器后端，并在每次
+`render()` 调用时发送快照：
+
+```python
+from tactics2d.envs import ParkingEnv
+
+env = ParkingEnv(render_mode="browser", render_fps=30)
+obs, info = env.reset()
+
+for _ in range(200):
+    obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+    env.render()              # 把当前帧发送到浏览器
+    if terminated or truncated:
+        break
+
+env.close()
+```
+
+浏览器后端会自动管理服务生命周期：
+
+- 如果服务已经在运行（例如通过 `tactics2d start` 启动），后端会直接连接它。
+- 如果没有服务在运行，后端会以子进程方式启动一个。
+- 调用 `backend.close()` 或 `env.close()` 只会断开连接，**不会**停止由外部管理的服务。
+
+其他支持的渲染模式：
+
+| 模式 | 后端 | 输出 |
+|------|------|------|
+| `"human"` | pygame 窗口 | 本地屏幕窗口 |
+| `"rgb_array"` | pygame（离屏） | `render()` 返回 NumPy 数组 |
+| `"browser"` | 浏览器 HTTP + WebSocket | 远程浏览器标签页 |
+| `"matplotlib"` | Matplotlib 图像 | NumPy 数组或保存的图片 |
+| `"none"` | NullBackend（空操作） | `None` |
+
+### 录制输出
+
+用 `GifRecorder` 或 `FrameExporter` 包装任意后端，可以把渲染帧保存为 GIF 动画
+或 PNG 序列：
+
+```python
+from tactics2d.display import create_display_backend, SceneSnapshot
+from tactics2d.display.recorder import GifRecorder
+
+backend = create_display_backend("matplotlib")
+recorder = GifRecorder(backend, output_path="output.gif", fps=10)
+
+for frame in range(100):
+    snapshot = build_snapshot(frame)
+    recorder.render(snapshot)    # 渲染并记录
+
+recorder.save()    # 写出 output.gif
+recorder.close()
+```
+
+依赖说明：
+
+- **GIF 导出**：安装 `imageio`（`pip install imageio`）
+- **PNG 序列导出**：安装 `Pillow`（`pip install Pillow`）
+- **浏览器后端**：无需额外安装——`fastapi`、`uvicorn` 和 `orjson` 是 tactics2d
+  的核心依赖，随包一起安装

--- a/docs/tutorial/browser_frontend.md
+++ b/docs/tutorial/browser_frontend.md
@@ -147,7 +147,12 @@ recommended way to render scenes in new code.
 ### Using the Factory
 
 ```python
-from tactics2d.display import create_display_backend, SceneSnapshot
+from tactics2d.display import (
+    CameraMetadata,
+    ParticipantElement,
+    SceneSnapshot,
+    create_display_backend,
+)
 
 # Create a browser backend (auto-starts the server if needed)
 backend = create_display_backend("browser")
@@ -236,5 +241,5 @@ Dependencies:
 
 - **GIF export**: install `imageio` (`pip install imageio`)
 - **PNG sequence export**: install `Pillow` (`pip install Pillow`)
-- **Browser backend**: install `fastapi` and `uvicorn` (included as optional
-  dependencies of tactics2d)
+- **Browser backend**: no extra installation needed — `fastapi`, `uvicorn`, and
+  `orjson` are core dependencies of tactics2d and are installed with the package

--- a/tactics2d/envs/parking.py
+++ b/tactics2d/envs/parking.py
@@ -108,7 +108,7 @@ class ParkingEnv(gym.Env):
 
         Args:
             type_proportion (float, optional): The proportion of "bay" parking scenario in all generated scenarios. It should be in the range of [0, 1]. If the input is out of the range, it will be clipped to the range. When it is 0, the generator only generates "parallel" parking scenarios. When it is 1, the generator only generates "bay" parking scenarios.
-            render_mode (str, optional): The mode of the rendering. It can be "human", "rgb_array", "none" or None.
+            render_mode (str, optional): The mode of the rendering. It can be "human", "rgb_array", "browser", "matplotlib", "none" or None.
             render_fps (int, optional): The frame rate of the rendering.
             max_step (int, optional): The maximum time step of the scenario.
             continuous (bool, optional): Whether to use continuous action space.

--- a/tactics2d/envs/racing.py
+++ b/tactics2d/envs/racing.py
@@ -81,7 +81,7 @@ class RacingEnv(gym.Env):
         """Initialize the racing environment.
 
         Args:
-            render_mode (str, optional): The mode of the rendering. It can be "human", "rgb_array", "none" or None. Defaults to "human".
+            render_mode (str, optional): The mode of the rendering. It can be "human", "rgb_array", "browser", "matplotlib", "none" or None. Defaults to "human".
             render_fps (int, optional): The frame rate of the rendering.
             max_step (int, optional): The maximum time step of the scenario. Defaults to 100000.
             continuous (bool, optional): Whether to use continuous action space. Defaults to True.


### PR DESCRIPTION
## Summary

Documentation fixes found while cross-checking `docs/tutorial/browser_frontend.md` against the current `master` code (post display-module refactor #283):

### Fixed
- Fixed browser frontend tutorial incorrectly stating `fastapi`/`uvicorn` are optional dependencies (they are core dependencies installed with the package), and added missing `ParticipantElement`/`CameraMetadata` imports in the display backend example.
- Fixed `render_mode` docstrings in `ParkingEnv` and `RacingEnv` missing the supported `browser` and `matplotlib` modes (now consistent with `_metadata["render_modes"]` and the tutorial).
- Synchronized the Chinese browser frontend tutorial with the English version by adding the missing "Unified Display Backend" section (factory usage, environment integration, render mode table, recording output).

## Verification

- All four names in the fixed import example (`CameraMetadata`, `ParticipantElement`, `SceneSnapshot`, `create_display_backend`) are exported from `tactics2d.display.__all__`.
- `fastapi>=0.110.0`, `uvicorn[standard]>=0.27.0`, `orjson` confirmed in `requirements.txt` (core deps, no web extra exists in `pyproject.toml`).
- `browser`/`matplotlib` confirmed in `_metadata["render_modes"]` of both envs; `create_display_backend()` dispatches both.
- Docs-only + docstring-only changes; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)