### PR TITLE
🐛 Fix: OSMParser id collisions and unordered members on official lanelet2 maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed `OSMParser` failing on official levelXdata lanelet2 maps (issue #291): OSM keeps node/way/relation ids in independent namespaces while `Map` enforces one, so colliding way/relation ids (6 of 7 official exiD maps) are now pre-scanned and remapped into a free id range with every member reference resolved through the same tables; lanelet relation members that are not listed head-to-tail are stitched by matching endpoints in any order (bridging the nearest gap with a warning), and malformed elements (missing node references, empty member lists) degrade to a skip-with-warning instead of aborting the whole map. All 13 previously failing official maps (exiD lanelet2, raw inD/rounD lanelets) parse now.
 - Fixed `NetXMLParser._get_lane_subtype` incorrectly declared as `@staticmethod` with a `self` parameter, causing all lane parsing to fail silently.
 - Fixed `NetXMLParser._offset_line` referencing undefined normal vector variables when consecutive points have zero distance.
 - Fixed `NetXMLParser` not reading the lane element's `width` attribute, falling back to inaccurate heuristic estimation.

--- a/tactics2d/map/parser/parse_osm.py
+++ b/tactics2d/map/parser/parse_osm.py
@@ -33,6 +33,57 @@ class OSMParser:
                 Defaults to False.
         """
         self.lanelet2 = lanelet2
+        self._way_id_map = {}
+        self._relation_id_map = {}
+
+    def _mapped_way_id(self, id_: int) -> int:
+        return self._way_id_map.get(id_, id_)
+
+    def _mapped_relation_id(self, id_: int) -> int:
+        return self._relation_id_map.get(id_, id_)
+
+    def _build_id_remaps(self, xml_root: ET.Element) -> None:
+        """Remap way/relation ids that collide with other element kinds.
+
+        OSM keeps node, way, and relation ids in independent namespaces, while
+        :class:`Map` enforces a single one; official levelXdata lanelet2 maps
+        reuse numeric ids across kinds (e.g. exiD node 1500 vs way 1500).
+        Colliding ways and relations get ids from a free range, and every
+        member reference is resolved through the same tables, so maps without
+        collisions keep their original ids untouched.
+        """
+        node_ids = {int(node.attrib["id"]) for node in xml_root.findall("node")}
+        way_ids = [int(way.attrib["id"]) for way in xml_root.findall("way")]
+        relation_ids = [int(relation.attrib["id"]) for relation in xml_root.findall("relation")]
+
+        self._way_id_map = {}
+        self._relation_id_map = {}
+        used = set(node_ids)
+        next_id = max(used.union(way_ids, relation_ids), default=0) + 1
+
+        for way_id in way_ids:
+            if way_id in used:
+                self._way_id_map[way_id] = next_id
+                used.add(next_id)
+                next_id += 1
+            else:
+                used.add(way_id)
+
+        for relation_id in relation_ids:
+            if relation_id in used:
+                self._relation_id_map[relation_id] = next_id
+                used.add(next_id)
+                next_id += 1
+            else:
+                used.add(relation_id)
+
+        if self._way_id_map or self._relation_id_map:
+            logging.warning(
+                "%d way id(s) and %d relation id(s) collide with other element kinds; "
+                "remapped them to a free id range.",
+                len(self._way_id_map),
+                len(self._relation_id_map),
+            )
 
     def _append_point_list(self, point_list: list, new_points: list, component_id: int) -> None:
         """Append new points to an existing point list, handling direction alignment.
@@ -58,6 +109,67 @@ class OSMParser:
             raise SyntaxError(f"Points on the side of relation {component_id} is not continuous.")
 
         point_list += new_points[1:]
+
+    def _stitch_polylines(self, segments: list, component_id: int) -> list:
+        """Stitch member polylines into one chain regardless of member order.
+
+        Official lanelet2 exports do not guarantee that relation members are
+        listed head-to-tail, so segments are joined by matching endpoints in
+        any order and orientation. When no exact match remains, the chain is
+        bridged to the nearest remaining segment with a warning instead of
+        aborting the whole map.
+
+        Args:
+            segments (list): Lists of points, one per relation member.
+            component_id (int): The id of the relation, used for messages.
+
+        Returns:
+            list: The stitched point chain.
+        """
+        segments = [list(segment) for segment in segments if len(segment) > 0]
+        if not segments:
+            return []
+
+        chain = segments.pop(0)
+        while segments:
+            joined = False
+            for index, segment in enumerate(segments):
+                try:
+                    self._append_point_list(chain, list(segment), component_id)
+                except SyntaxError:
+                    continue
+                segments.pop(index)
+                joined = True
+                break
+            if joined:
+                continue
+
+            best_cost = None
+            best = None
+            for index, segment in enumerate(segments):
+                for chain_flip, chain_end in ((False, chain[-1]), (True, chain[0])):
+                    for segment_flip, segment_start in ((False, segment[0]), (True, segment[-1])):
+                        cost = (chain_end[0] - segment_start[0]) ** 2 + (
+                            chain_end[1] - segment_start[1]
+                        ) ** 2
+                        if best_cost is None or cost < best_cost:
+                            best_cost = cost
+                            best = (index, chain_flip, segment_flip)
+
+            index, chain_flip, segment_flip = best
+            segment = segments.pop(index)
+            if chain_flip:
+                chain.reverse()
+            if segment_flip:
+                segment.reverse()
+            logging.warning(
+                "Members of relation %s are not connected; bridging a gap of %.2f m.",
+                component_id,
+                best_cost**0.5,
+            )
+            chain += segment
+
+        return chain
 
     def _get_tags(self, xml_node: ET.Element) -> dict:
         """Parse OSM tags from an XML node into a dictionary.
@@ -151,18 +263,18 @@ class OSMParser:
         Returns:
             Area: The parsed area, or None if the outer boundary is empty or parsing fails.
         """
-        area_id = int(xml_node.attrib["id"])
+        area_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(inner=[], outer=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "outer":
-                line_ids["outer"].append(member_id)
+                line_ids["outer"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "inner":
-                line_ids["inner"].append(member_id)
+                line_ids["inner"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
         outer_point_list = []
         for line_id in line_ids["outer"]:
@@ -304,7 +416,7 @@ class OSMParser:
             Area | RoadLine: An Area if the way is closed or tagged as area,
                 otherwise a RoadLine.
         """
-        id_ = int(xml_node.attrib["id"])
+        id_ = self._mapped_way_id(int(xml_node.attrib["id"]))
         point_list = []
         point_ids = []
 
@@ -333,7 +445,7 @@ class OSMParser:
         Returns:
             Area | RoadLine | Regulatory: The parsed road element, or None if parsing fails.
         """
-        id_ = int(xml_node.attrib["id"])
+        id_ = self._mapped_relation_id(int(xml_node.attrib["id"]))
         tags = self._get_tags(xml_node)
         type_ = tags.pop("type")
         road_element = None
@@ -342,22 +454,16 @@ class OSMParser:
             road_element = self._parse_area(xml_node, map_)
 
         elif type_ == "route":
-            point_list = []
             line_ids = []
             for member in xml_node.findall("member"):
                 if member.attrib["type"] == "way":
-                    line_ids.append(int(member.attrib["ref"]))
-            for line_id in line_ids:
-                if len(point_list) == 0:
-                    if map_.roadlines.get(line_id):
-                        point_list = list(map_.roadlines[line_id].geometry.coords)
-                if map_.roadlines.get(line_id):
-                    new_points = list(map_.roadlines[line_id].geometry.coords)
-                    try:
-                        self._append_point_list(point_list, new_points, id_)
-                    except SyntaxError as err:
-                        logging.error(err)
-                        return None
+                    line_ids.append(self._mapped_way_id(int(member.attrib["ref"])))
+            segments = [
+                list(map_.roadlines[line_id].geometry.coords)
+                for line_id in line_ids
+                if map_.roadlines.get(line_id)
+            ]
+            point_list = self._stitch_polylines(segments, id_)
             road_element = RoadLine(id_, LineString(point_list), type_="route", custom_tags=tags)
 
         elif type_ == "restriction":
@@ -367,6 +473,10 @@ class OSMParser:
             vias = {}
             for member in xml_node.findall("member"):
                 member_id = int(member.attrib["ref"])
+                if member.attrib["type"] == "way":
+                    member_id = self._mapped_way_id(member_id)
+                elif member.attrib["type"] == "relation":
+                    member_id = self._mapped_relation_id(member_id)
                 if member.attrib["role"] == "from":
                     froms[member_id] = member.attrib["type"]
                 elif member.attrib["role"] == "to":
@@ -391,11 +501,17 @@ class OSMParser:
         Returns:
             RoadLine: A roadline with Lanelet2 tags.
         """
-        line_id = int(xml_node.attrib["id"])
+        line_id = self._mapped_way_id(int(xml_node.attrib["id"]))
         point_list = []
 
         for node in xml_node.findall("nd"):
-            point_list.append(map_.nodes[int(node.attrib["ref"])].location)
+            node_id = int(node.attrib["ref"])
+            if node_id not in map_.nodes:
+                logging.warning("Way %s references missing node %s; skipped it.", line_id, node_id)
+                continue
+            point_list.append(map_.nodes[node_id].location)
+        if len(point_list) < 2:
+            raise SyntaxError(f"Way {line_id} has fewer than 2 resolvable nodes.")
         linestring = LineString(point_list)
 
         tags = self._get_lanelet2_tags(xml_node)
@@ -412,25 +528,27 @@ class OSMParser:
         Returns:
             Lane: A lane with Lanelet2 tags and aligned left/right boundaries.
         """
-        lane_id = int(xml_node.attrib["id"])
+        lane_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(left=[], right=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "left":
-                line_ids["left"].append(member_id)
+                line_ids["left"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "right":
-                line_ids["right"].append(member_id)
+                line_ids["right"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
         point_list = {}
         for side in ["left", "right"]:
-            point_list[side] = list(map_.roadlines[line_ids[side][0]].geometry.coords)
-            for line_id in line_ids[side][1:]:
-                new_nodes = list(map_.roadlines[line_id].geometry.coords)
-                self._append_point_list(point_list[side], new_nodes, lane_id)
+            segments = [
+                list(map_.roadlines[line_id].geometry.coords) for line_id in line_ids[side]
+            ]
+            point_list[side] = self._stitch_polylines(segments, lane_id)
+            if len(point_list[side]) < 2:
+                raise SyntaxError(f"Lane {lane_id} has no usable {side} boundary.")
 
         left_side = LineString(point_list["left"])
         right_side = LineString(point_list["right"])
@@ -468,23 +586,23 @@ class OSMParser:
         Returns:
             Area: An area with Lanelet2 tags.
         """
-        area_id = int(xml_node.attrib["id"])
+        area_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(inner=[], outer=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "outer":
-                line_ids["outer"].append(member_id)
+                line_ids["outer"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "inner":
-                line_ids["inner"].append(member_id)
+                line_ids["inner"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
-        outer_point_list = list(map_.roadlines[line_ids["outer"][0]].geometry.coords)
-        for line_id in line_ids["outer"][1:]:
-            new_points = list(map_.roadlines[line_id].geometry.coords)
-            self._append_point_list(outer_point_list, new_points, area_id)
+        outer_segments = [
+            list(map_.roadlines[line_id].geometry.coords) for line_id in line_ids["outer"]
+        ]
+        outer_point_list = self._stitch_polylines(outer_segments, area_id)
         if outer_point_list[0] != outer_point_list[-1]:
             logging.warning("The outer boundary of area %d is not closed.", area_id)
 
@@ -518,14 +636,16 @@ class OSMParser:
         Returns:
             Regulatory: A regulatory element with Lanelet2 tags.
         """
-        regulatory_id = int(xml_node.attrib["id"])
+        regulatory_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         relations = {}
         ways = {}
         for member in xml_node.findall("member"):
             if member.attrib["type"] == "relation":
-                relations[int(member.attrib["ref"])] = member.attrib["role"]
+                relations[self._mapped_relation_id(int(member.attrib["ref"]))] = member.attrib[
+                    "role"
+                ]
             elif member.attrib["type"] == "way":
-                ways[int(member.attrib["ref"])] = member.attrib["role"]
+                ways[self._mapped_way_id(int(member.attrib["ref"]))] = member.attrib["role"]
 
         regulatory_tags = self._get_lanelet2_tags(xml_node)
         if "speed_limit" in regulatory_tags:
@@ -549,6 +669,7 @@ class OSMParser:
             Map: A Tactics2D Map populated with all elements parsed from the OSM file.
         """
         xml_root = ET.parse(file_path).getroot()
+        self._build_id_remaps(xml_root)
 
         if configs is not None:
             project_rule = configs.get("project_rule", None)
@@ -596,33 +717,57 @@ class OSMParser:
             for xml_node in all_nodes:
                 map_.add_node(self._parse_nodes_no_proj(xml_node, lat0, lon0))
 
+        # A single malformed element (missing node reference, empty member
+        # list, degenerate geometry) degrades to a warning instead of
+        # aborting the whole map.
+        recoverable_errors = (KeyError, IndexError, ValueError, SyntaxError)
+
         if self.lanelet2:
             for xml_node in xml_root.findall("way"):
                 if xml_node.get("action") == "delete":
                     continue
-                map_.add_roadline(self._parse_roadline_lanelet2(xml_node, map_))
+                try:
+                    map_.add_roadline(self._parse_roadline_lanelet2(xml_node, map_))
+                except recoverable_errors as error:
+                    logging.warning(
+                        "Skipping way %s: %s", xml_node.attrib.get("id"), error
+                    )
 
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
                 for tag in xml_node.findall("tag"):
-                    if tag.attrib["v"] == "lanelet":
-                        map_.add_lane(self._parse_lane_lanelet2(xml_node, map_))
-                    elif tag.attrib["v"] in ["multipolygon", "area"]:
-                        map_.add_area(self._parse_area_lanelet2(xml_node, map_))
+                    try:
+                        if tag.attrib["v"] == "lanelet":
+                            map_.add_lane(self._parse_lane_lanelet2(xml_node, map_))
+                        elif tag.attrib["v"] in ["multipolygon", "area"]:
+                            map_.add_area(self._parse_area_lanelet2(xml_node, map_))
+                    except recoverable_errors as error:
+                        logging.warning(
+                            "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                        )
 
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
                 for tag in xml_node.findall("tag"):
                     if tag.attrib["v"] == "regulatory_element":
-                        map_.add_regulatory(self._parse_regulatory_lanelet2(xml_node))
+                        try:
+                            map_.add_regulatory(self._parse_regulatory_lanelet2(xml_node))
+                        except recoverable_errors as error:
+                            logging.warning(
+                                "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                            )
 
         else:
             for xml_node in xml_root.findall("way"):
                 if xml_node.get("action") == "delete":
                     continue
-                road_element = self._parse_way(xml_node, map_)
+                try:
+                    road_element = self._parse_way(xml_node, map_)
+                except recoverable_errors as error:
+                    logging.warning("Skipping way %s: %s", xml_node.attrib.get("id"), error)
+                    continue
 
                 if isinstance(road_element, RoadLine):
                     map_.add_roadline(road_element)
@@ -632,7 +777,13 @@ class OSMParser:
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
-                road_element = self._parse_relation(xml_node, map_)
+                try:
+                    road_element = self._parse_relation(xml_node, map_)
+                except recoverable_errors as error:
+                    logging.warning(
+                        "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                    )
+                    continue
 
                 if isinstance(road_element, RoadLine):
                     map_.add_roadline(road_element)

--- a/tests/test_map_parser.py
+++ b/tests/test_map_parser.py
@@ -175,3 +175,136 @@ def test_net_xml_parser(runtime_dir, map_path, img_name):
     matplotlib_renderer.update(geometry_data)
     matplotlib_renderer.save_single_frame(save_to=runtime_dir / img_name)
     matplotlib_renderer.destroy()
+
+
+def _write_lanelet2_osm(path, nodes, ways, relations):
+    """Write a minimal lanelet2 OSM file from (id, ...) tuples."""
+    lines = ['<?xml version="1.0" encoding="UTF-8"?>', '<osm version="0.6">']
+    for node_id, lat, lon in nodes:
+        lines.append(f'  <node id="{node_id}" lat="{lat}" lon="{lon}"/>')
+    for way_id, node_ids in ways:
+        lines.append(f'  <way id="{way_id}">')
+        lines.extend(f'    <nd ref="{node_id}"/>' for node_id in node_ids)
+        lines.append('    <tag k="type" v="line_thin"/>')
+        lines.append("  </way>")
+    for relation_id, members, tags in relations:
+        lines.append(f'  <relation id="{relation_id}">')
+        for member_type, ref, role in members:
+            lines.append(f'    <member type="{member_type}" ref="{ref}" role="{role}"/>')
+        for key, value in tags:
+            lines.append(f'    <tag k="{key}" v="{value}"/>')
+        lines.append("  </relation>")
+    lines.append("</osm>")
+    path.write_text("\n".join(lines))
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_remaps_colliding_ids(tmp_path):
+    """Node/way/relation ids live in independent OSM namespaces (issue #291)."""
+    osm = tmp_path / "collide.osm"
+    # Node 1, way 1, and relation 1 coexist; ways 2/3 also collide with nodes.
+    _write_lanelet2_osm(
+        osm,
+        nodes=[(1, 50.0, 6.0), (2, 50.0001, 6.0), (3, 50.0, 6.0002), (4, 50.0001, 6.0002)],
+        ways=[(1, [1, 3]), (2, [2, 4])],
+        relations=[
+            (
+                1,
+                [("way", 1, "left"), ("way", 2, "right"), ("relation", 5, "regulatory_element")],
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                5,
+                [("relation", 1, "refers")],
+                [("type", "regulatory_element"), ("subtype", "speed_limit")],
+            ),
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    assert len(map_.roadlines) == 2
+    assert len(map_.lanes) == 1
+    assert len(map_.regulations) == 1
+    lane = next(iter(map_.lanes.values()))
+    # Member references follow the remapped way ids.
+    assert all(line_id in map_.roadlines for side in ("left", "right") for line_id in lane.line_ids[side])
+    # The regulatory element still points at the (remapped) lane relation.
+    regulatory = next(iter(map_.regulations.values()))
+    assert set(regulatory.relations) == {lane.id_}
+    assert lane.regulatory_ids == {regulatory.id_}
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_stitches_out_of_order_members(tmp_path):
+    """Relation members are not guaranteed head-to-tail; stitch by endpoints."""
+    osm = tmp_path / "unordered.osm"
+    # Left side is split into two ways listed in reverse order: 20 then 10.
+    _write_lanelet2_osm(
+        osm,
+        nodes=[
+            (101, 50.0, 6.0),
+            (102, 50.0, 6.0001),
+            (103, 50.0, 6.0002),
+            (104, 50.0001, 6.0),
+            (105, 50.0001, 6.0002),
+        ],
+        ways=[(10, [101, 102]), (20, [102, 103]), (30, [104, 105])],
+        relations=[
+            (
+                40,
+                [("way", 20, "left"), ("way", 10, "left"), ("way", 30, "right")],
+                [("type", "lanelet"), ("subtype", "road")],
+            )
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    assert len(map_.lanes) == 1
+    lane = next(iter(map_.lanes.values()))
+    assert len(lane.left_side.coords) == 3  # both left segments joined
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_skips_broken_elements(tmp_path):
+    """Missing node references degrade to skipped elements, not a failed map."""
+    osm = tmp_path / "broken.osm"
+    _write_lanelet2_osm(
+        osm,
+        nodes=[
+            (101, 50.0, 6.0),
+            (102, 50.0, 6.0002),
+            (103, 50.0001, 6.0),
+            (104, 50.0001, 6.0002),
+            (105, 50.0002, 6.0),
+        ],
+        ways=[
+            (10, [101, 102]),
+            (20, [103, 104]),
+            (30, [105, 999999]),  # dangling node reference
+        ],
+        relations=[
+            (
+                40,
+                [("way", 10, "left"), ("way", 20, "right")],
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                41,
+                [("way", 10, "left"), ("way", 30, "right")],  # references the broken way
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                42,
+                [],  # no members at all
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    # Way 30 degenerates to a single point and is skipped; lane 40 survives.
+    assert 30 not in map_.roadlines
+    assert set(map_.lanes) == {40}


### PR DESCRIPTION
## Summary

Fixes #291 — `OSMParser` aborted on official levelXdata lanelet2 maps for three independent reasons; all 13 previously failing official map files parse now.

### Fixed

- Fixed `OSMParser` failing on official levelXdata lanelet2 maps (issue #291): OSM keeps node/way/relation ids in independent namespaces while `Map` enforces one, so colliding way/relation ids (6 of 7 official exiD maps) are now pre-scanned and remapped into a free id range with every member reference resolved through the same tables; lanelet relation members that are not listed head-to-tail are stitched by matching endpoints in any order (bridging the nearest gap with a warning), and malformed elements (missing node references, empty member lists) degrade to a skip-with-warning instead of aborting the whole map.

## Design notes

- **Id collisions** (`KeyError: The id of Roadline 1500 is used by the other road element`): the exiD maps reuse numeric ids across kinds (node 1500 vs way 1500, way 2066 vs relation 2066). `parse()` now pre-scans the file and assigns colliding way/relation ids from a free range (`max(all ids) + 1` onward, deterministic per file). Every member reference — lanelet left/right/regulatory members, area outer/inner rings, route members, restriction from/to/via, regulatory way/relation refs — resolves through the same remap tables, so cross-references stay intact. Maps without collisions keep every original id; exiD_3 (the one map that already parsed) produces byte-identical element counts.
- **Unordered relation members** (`SyntaxError: Points on the side of relation … is not continuous`): official inD/rounD raw lanelet exports list boundary segments out of order. A new `_stitch_polylines` joins member polylines by matching endpoints in any order and orientation (the previous behavior — strictly sequential joins — is the trivial case), and only when no exact match remains bridges to the nearest segment with a warning.
- **Broken references degrade instead of aborting**: ways referencing missing nodes (`KeyError: 243513098`) skip the unresolvable points (or the way, if fewer than 2 remain); relations whose members are missing or empty are skipped with a warning naming the element. The whole-map parse keeps going.

## Testing

- `tests/test_map_parser.py`: 3 new unit tests on synthetic OSM fixtures — cross-kind id collision with reference integrity (lane ↔ regulatory element both remapped and still linked), out-of-order member stitching, and skip-with-warning on dangling node references / empty relations. The suite's 7 pre-existing failures (missing sample map data, identical on master) are untouched; everything else passes.
- **Official maps**: all 7 exiD `maps/lanelet2/*.osm` parse (previously 1), with exiD_3's element counts unchanged; all 4 raw inD `lanelets/location*.osm` and both failing rounD lanelets parse.
- **exiD preview sweep**: with this commit merged into the preview branch (#292) locally, all **93/93** exiD recordings load end-to-end through the browser-preview pipeline (previously 8 — only location 3's recordings worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
