### PR TITLE
🔨 map.generator: refine road taper utilities

### DIFF
--- a/tactics2d/map/generator/road_segment/element_builder.py
+++ b/tactics2d/map/generator/road_segment/element_builder.py
@@ -11,7 +11,7 @@ from typing import Any
 import numpy as np
 from shapely.geometry import LineString
 
-from tactics2d.geometry import polyline_length, sample_by_s
+from tactics2d.geometry import cumulative_s, polyline_length, sample_by_s
 from tactics2d.map.element import Junction, Lane, LaneRelationship, RoadLine
 from tactics2d.map.generator.rules.module_types import RoadPort, build_port
 
@@ -399,7 +399,17 @@ def build_junction_arm_ports(
     Returns:
         Dict of named :class:`RoadPort` instances keyed
         ``"arm_{i}_in"`` / ``"arm_{i}_out"``.
+
+    Raises:
+        ValueError: If the lane-id lists do not contain one entry per arm.
     """
+    arm_num = len(normalized_arms)
+    if len(outgoing_lane_ids) != arm_num or len(incoming_lane_ids) != arm_num:
+        raise ValueError(
+            "outgoing_lane_ids and incoming_lane_ids must each contain one "
+            "lane-id list per normalized arm."
+        )
+
     ports: dict[str, RoadPort] = {}
 
     for arm_idx, arm in enumerate(normalized_arms):
@@ -442,3 +452,172 @@ def build_junction_arm_ports(
         )
 
     return ports
+
+
+def variable_offset_polyline(
+    centerline: np.ndarray, start_offset: float, end_offset: float
+) -> np.ndarray:
+    """Offset a polyline with a smoothly varying lateral offset.
+
+    The offset transitions from ``start_offset`` to ``end_offset`` via a
+    quintic smoothstep function of arc length, producing zero first **and**
+    second derivatives at both ends (C² continuity).  Compared with the
+    simpler cubic smoothstep, the quintic avoids curvature jumps at the
+    taper entry / exit, which makes the resulting boundary noticeably
+    smoother when lane counts change.
+
+    Args:
+        centerline: Centreline points with shape ``(N, 2)``.
+        start_offset: Lateral offset at the entry end in metres.
+            Positive = left of travel direction.
+        end_offset: Lateral offset at the exit end in metres.
+            Positive = left of travel direction.
+
+    Returns:
+        Offset polyline with shape ``(N, 2)``.
+    """
+    pts = np.asarray(centerline, dtype=float)
+
+    if len(pts) < 2:
+        return pts.copy()
+
+    cum = cumulative_s(pts)
+    total = cum[-1]
+    t = np.zeros(len(pts)) if total < 1e-9 else cum / total
+    # quintic smoothstep: t^3 (6 t^2 - 15 t + 10)
+    t = t * t * t * (6.0 * t * t - 15.0 * t + 10.0)
+
+    tangents = np.empty_like(pts)
+    tangents[0] = pts[1] - pts[0]
+    tangents[-1] = pts[-1] - pts[-2]
+    if len(pts) > 2:
+        tangents[1:-1] = pts[2:] - pts[:-2]
+    norms = np.linalg.norm(tangents, axis=1, keepdims=True)
+    tangents /= np.where(norms < 1e-9, 1.0, norms)
+    normals = np.column_stack([-tangents[:, 1], tangents[:, 0]])
+
+    offsets = float(start_offset) + (float(end_offset) - float(start_offset)) * t
+    return pts + offsets[:, None] * normals
+
+
+def lane_role(start_width: float, end_width: float) -> str:
+    """Classify a lane's role in a taper or adapter transition.
+
+    Args:
+        start_width: Lane width at the entry end in metres.
+        end_width: Lane width at the exit end in metres.
+
+    Returns:
+        ``"added"`` if the lane opens from zero width, ``"dropped"`` if it
+        closes to zero, or ``"through"`` otherwise.
+    """
+    eps = 1e-3
+    if start_width <= eps and end_width > eps:
+        return "added"
+    if start_width > eps and end_width <= eps:
+        return "dropped"
+    return "through"
+
+
+def apply_lane_side_shift(offsets: list[float], lane_side: str) -> list[float]:
+    """Shift boundary offsets so all lanes sit on one side of the centreline.
+
+    When ``lane_side`` is ``"right"`` the leftmost boundary is pinned to zero;
+    when ``"left"`` the rightmost boundary is pinned to zero.  ``"center"``
+    leaves the symmetric offsets unchanged.
+
+    Args:
+        offsets: Boundary offsets sorted left-to-right (most positive to most
+            negative).  ``len(offsets) == lane_num + 1``.
+        lane_side: ``"center"`` (no shift), ``"left"`` (all lanes left of
+            centreline), or ``"right"`` (all lanes right of centreline).
+
+    Returns:
+        New offset list with the requested lateral shift applied.  The shift
+        preserves relative spacing so the lane widths are unchanged.
+
+    Raises:
+        ValueError: If ``lane_side`` is not one of the three valid values.
+    """
+    if lane_side == "center":
+        return list(offsets)
+
+    if lane_side == "right":
+        shift = float(offsets[0])
+    elif lane_side == "left":
+        shift = float(offsets[-1])
+    else:
+        raise ValueError(f"lane_side must be 'center', 'left', or 'right', got {lane_side!r}")
+
+    return [float(o) - shift for o in offsets]
+
+
+def deduplicate_roadlines(
+    roadlines: list[RoadLine], lanes: list[Lane], step_size: float
+) -> tuple[list[RoadLine], list[Lane]]:
+    """Merge geometrically near-identical RoadLines and update Lane references.
+
+    Two roadlines are merged when their Hausdorff distance is within
+    ``2 * step_size``. This compares the complete geometries (in either
+    direction), avoiding false positives for curves that merely share similar
+    endpoints and length. When a merge occurs the first RoadLine in the input
+    list is kept and all Lane ``line_ids`` references to the discarded id are
+    rewritten.
+
+    This is useful after assembling multiple :class:`RoadModuleResult` objects
+    into a single map, where neighbouring modules may produce overlapping
+    boundary roadlines (e.g. two adapters sharing the same centreline).
+
+    Args:
+        roadlines: List of RoadLines to deduplicate.
+        lanes: Lanes whose ``line_ids`` may reference the duplicate roadlines.
+        step_size: Sampling interval used as the tolerance base.
+
+    Returns:
+        Tuple ``(deduped_roadlines, lanes)``.  ``lanes`` is mutated in place
+        (the return value is the same list for convenience).
+    """
+    if step_size <= 0.0:
+        raise ValueError("step_size must be positive.")
+
+    if len(roadlines) < 2:
+        return roadlines, lanes
+
+    tol = 2.0 * float(step_size)
+    n = len(roadlines)
+    id_merge_map: dict[str, str] = {}  # discarded_id -> kept_id
+
+    for i in range(n):
+        id_i = roadlines[i].id_
+        if id_i in id_merge_map:
+            continue
+
+        for j in range(i + 1, n):
+            id_j = roadlines[j].id_
+            if id_j in id_merge_map:
+                continue
+
+            if roadlines[i].geometry.hausdorff_distance(roadlines[j].geometry) <= tol:
+                id_merge_map[id_j] = id_i
+
+    if not id_merge_map:
+        return roadlines, lanes
+
+    # Update lane references
+    for lane in lanes:
+        for side in ("left", "right"):
+            if side not in lane.line_ids:
+                continue
+            updated: list[str] = []
+            seen: set[str] = set()
+            for lid in lane.line_ids[side]:
+                mapped = id_merge_map.get(lid, lid)
+                if mapped not in seen:
+                    seen.add(mapped)
+                    updated.append(mapped)
+            lane.line_ids[side] = updated
+
+    merged_ids = set(id_merge_map.keys())
+    deduped = [rl for rl in roadlines if rl.id_ not in merged_ids]
+
+    return deduped, lanes

--- a/tactics2d/map/generator/road_segment/junction_approach.py
+++ b/tactics2d/map/generator/road_segment/junction_approach.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from tactics2d.geometry import cumulative_s
@@ -17,52 +19,15 @@ from tactics2d.map.generator.rules.module_types import RoadModuleResult, RoadPor
 
 from .element_builder import (
     add_ordered_lane_neighbors,
+    apply_lane_side_shift,
     build_lane_from_boundaries,
     build_roadline_from_points,
+    lane_role,
+    variable_offset_polyline,
 )
 from .road_segment import RoadSegment
 
-
-def _variable_offset_polyline(
-    centerline: np.ndarray, start_offset: float, end_offset: float
-) -> np.ndarray:
-    """Offset a polyline with a smoothly varying lateral offset.
-
-    The offset transitions from ``start_offset`` to ``end_offset`` via a
-    smoothstep (zero-slope Hermite cubic) function of arc length, producing
-    zero first derivative at both ends.
-
-    Args:
-        centerline: Centreline points with shape ``(N, 2)``.
-        start_offset: Lateral offset at the entry end in metres.
-            Positive = left of travel direction.
-        end_offset: Lateral offset at the exit end in metres.
-            Positive = left of travel direction.
-
-    Returns:
-        Offset polyline with shape ``(N, 2)``.
-    """
-    pts = np.asarray(centerline, dtype=float)
-
-    if len(pts) < 2:
-        return pts.copy()
-
-    cum = cumulative_s(pts)
-    total = cum[-1]
-    t = np.zeros(len(pts)) if total < 1e-9 else cum / total
-    t = t * t * (3.0 - 2.0 * t)
-
-    tangents = np.empty_like(pts)
-    tangents[0] = pts[1] - pts[0]
-    tangents[-1] = pts[-1] - pts[-2]
-    if len(pts) > 2:
-        tangents[1:-1] = pts[2:] - pts[:-2]
-    norms = np.linalg.norm(tangents, axis=1, keepdims=True)
-    tangents /= np.where(norms < 1e-9, 1.0, norms)
-    normals = np.column_stack([-tangents[:, 1], tangents[:, 0]])
-
-    offsets = float(start_offset) + (float(end_offset) - float(start_offset)) * t
-    return pts + offsets[:, None] * normals
+logger = logging.getLogger(__name__)
 
 
 def _heading_at(pts: np.ndarray, at_end: bool = False) -> float:
@@ -78,6 +43,7 @@ def _approach_boundary_offsets(
     end_lane_num: int,
     lane_width: float,
     end_boundary_offsets: np.ndarray,
+    change_side: str = "both",
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute start and end lateral boundary offsets for the junction approach.
 
@@ -92,6 +58,10 @@ def _approach_boundary_offsets(
         end_boundary_offsets: Lateral offsets of the junction port's M lanes'
             boundaries, sorted from leftmost to rightmost in travel direction.
             Shape ``(M + 1,)``.
+        change_side: Which side lane-count changes happen on.
+            ``"left"`` — extra lane(s) on the left (innermost).
+            ``"right"`` — extra lane(s) on the right (outermost).
+            ``"both"`` — symmetric (default, matches the old behaviour).
 
     Returns:
         Tuple ``(start_offsets, end_offsets)`` each of shape ``(max(N, M) + 1,)``.
@@ -105,11 +75,19 @@ def _approach_boundary_offsets(
         [half - i * lane_width for i in range(start_lane_num + 1)], dtype=float
     )
 
+    def _pad_side(n_extra: int, side: str) -> tuple[int, int]:
+        if side == "left":
+            return (n_extra, 0)
+        if side == "right":
+            return (0, n_extra)
+        # "both" — symmetric
+        left = n_extra // 2
+        return (left, n_extra - left)
+
     # ---- end offsets: pad to max_n + 1 boundaries -----
     if len(end_offsets_arr) < max_n + 1:
         n_extra = max_n - end_lane_num
-        n_left = n_extra // 2
-        n_right = n_extra - n_left
+        n_left, n_right = _pad_side(n_extra, change_side)
 
         padded = np.empty(max_n + 1, dtype=float)
         padded[n_left : n_left + len(end_offsets_arr)] = end_offsets_arr
@@ -120,8 +98,7 @@ def _approach_boundary_offsets(
     # ---- pad start offsets if N < M -------------------
     if len(start_offsets) < max_n + 1:
         n_extra = max_n - start_lane_num
-        n_left = n_extra // 2
-        n_right = n_extra - n_left
+        n_left, n_right = _pad_side(n_extra, change_side)
 
         padded = np.empty(max_n + 1, dtype=float)
         padded[n_left : n_left + len(start_offsets)] = start_offsets
@@ -144,20 +121,60 @@ class JunctionApproach(RoadSegment):
 
     Attributes:
         step_size: Reference-line sampling interval in metres.
+        change_side: Which side lane-count changes happen on.
+        lane_side: Which side of the centreline the road-end lane group
+            occupies.  ``"center"`` (default) places lanes symmetrically;
+            ``"right"`` pins the leftmost boundary to the centreline (TwoWay
+            forward convention); ``"left"`` pins the rightmost boundary
+            (TwoWay backward convention).  The junction-end boundaries are
+            controlled by ``end_boundary_offsets`` and are never shifted.
+        min_taper_length: Minimum centreline length for the taper transition in
+            metres.  When the provided centreline is shorter a warning is emitted
+            but generation continues.
     """
 
-    def __init__(self, step_size: float = 0.1) -> None:
+    def __init__(
+        self,
+        step_size: float = 0.1,
+        change_side: str = "both",
+        lane_side: str = "center",
+        min_taper_length: float | None = None,
+        centerline_marking_token: str | None = None,
+    ) -> None:
         """Initialise the generator.
 
         Args:
             step_size: Reference-line sampling interval in metres.
+            change_side: Which side lane-count changes happen on.
+                ``"left"`` — extra lane(s) on the left (innermost side, towards
+                the junction centre).  ``"right"`` — extra lane(s) on the right
+                (outermost side).  ``"both"`` — symmetric padding.
+            lane_side: Which side of the centreline the road-end lane group
+                occupies.  ``"center"`` (default), ``"left"``, or ``"right"``.
+            min_taper_length: Minimum centreline length in metres for smooth
+                width transitions.  When ``None``, the minimum is computed
+                automatically as ``max(lane_width * |Δlane| * 3, 10)``.
+            centerline_marking_token: When ``lane_side`` is ``"right"`` or
+                ``"left"``, the road-end boundary pinned to the centreline
+                continues a TwoWay centre divider.  Pass a marking token string
+                to use that marking for the centreline boundary instead of the
+                default one-way edge rule.
 
         Raises:
-            ValueError: If ``step_size <= 0``.
+            ValueError: If ``step_size <= 0``, ``change_side`` is invalid, or
+                ``lane_side`` is invalid.
         """
         if step_size <= 0.0:
             raise ValueError("step_size must be positive.")
+        if change_side not in ("left", "right", "both"):
+            raise ValueError("change_side must be 'left', 'right', or 'both'.")
+        if lane_side not in ("center", "left", "right"):
+            raise ValueError("lane_side must be 'center', 'left', or 'right'.")
         self.step_size = step_size
+        self.change_side = change_side
+        self.lane_side = lane_side
+        self.min_taper_length = min_taper_length
+        self.centerline_marking_token = centerline_marking_token
 
     def build(  # type: ignore[override]
         self,
@@ -167,6 +184,9 @@ class JunctionApproach(RoadSegment):
         end_boundary_offsets: np.ndarray,
         lane_width: float = 3.5,
         speed_limit: float = 50.0,
+        change_side: str | None = None,
+        start_lane_side: str | None = None,
+        centerline_marking_token: str | None = None,
         *,
         id_offset: int = 0,
     ) -> RoadModuleResult:
@@ -182,6 +202,12 @@ class JunctionApproach(RoadSegment):
                 (leftmost to rightmost in travel direction), shape ``(M + 1,)``.
             lane_width: Uniform lane width in metres at the road side.
             speed_limit: Speed limit in km/h for the approach lanes.
+            change_side: Per-call override for ``self.change_side``.
+                ``None`` uses the generator default.
+            start_lane_side: Per-call override for ``self.lane_side``.
+                ``None`` uses the generator default.  Only affects the road-end
+                boundary offsets; the junction end is controlled by
+                ``end_boundary_offsets`` and is never shifted.
             id_offset: First element id.
 
         Returns:
@@ -206,22 +232,73 @@ class JunctionApproach(RoadSegment):
             raise ValueError("lane_width must be positive.")
 
         end_offs_arr = np.asarray(end_boundary_offsets, dtype=float)
-        if len(end_offs_arr) != end_n + 1:
+        if end_offs_arr.ndim != 1 or len(end_offs_arr) != end_n + 1:
             raise ValueError(
                 f"end_boundary_offsets must have end_lane_num + 1 = {end_n + 1} "
                 f"elements, got {len(end_offs_arr)}."
             )
+        if not np.all(np.isfinite(end_offs_arr)):
+            raise ValueError("end_boundary_offsets must contain only finite values.")
+        if np.any(np.diff(end_offs_arr) >= -1e-6):
+            raise ValueError(
+                "end_boundary_offsets must be strictly decreasing from leftmost to rightmost."
+            )
 
         center_pts = np.asarray(centerline, dtype=float)
+        if center_pts.ndim != 2 or center_pts.shape[1] != 2:
+            raise ValueError(f"centreline must have shape (N, 2), got {center_pts.shape}.")
         if len(center_pts) < 2:
             raise ValueError("centreline must have at least 2 points.")
+        if not np.all(np.isfinite(center_pts)):
+            raise ValueError("centreline must contain only finite values.")
+
+        # ---- resolve change_side ---------------------------------------
+        side = self.change_side if change_side is None else change_side
+        if side not in ("left", "right", "both"):
+            raise ValueError(f"change_side must be 'left', 'right', or 'both', got {side!r}.")
+
+        # ---- resolve lane_side -----------------------------------------
+        road_side = start_lane_side if start_lane_side is not None else self.lane_side
+        if road_side not in ("center", "left", "right"):
+            raise ValueError(f"lane_side must be 'center', 'left', or 'right', got {road_side!r}")
+        cl_token = (
+            centerline_marking_token
+            if centerline_marking_token is not None
+            else self.centerline_marking_token
+        )
+
+        # ---- minimum taper length check --------------------------------
+        lane_delta = abs(end_n - start_n)
+        min_len = self.min_taper_length
+        if min_len is None:
+            min_len = max(lane_w * lane_delta * 3, 10.0)
+
+        center_len = float(cumulative_s(center_pts)[-1])
+        if lane_delta > 0 and center_len < min_len:
+            logger.warning(
+                "Taper centreline length %.1f m is shorter than recommended "
+                "minimum %.1f m for a %d→%d lane transition (Δ=%d×%.1f m). "
+                "The resulting boundaries may be noticeably stiff.",
+                center_len,
+                min_len,
+                start_n,
+                end_n,
+                lane_delta,
+                lane_w,
+            )
 
         # ---- boundary offsets ------------------------------------------
-        start_offsets, end_offsets = _approach_boundary_offsets(
+        raw_start_offsets, end_offsets = _approach_boundary_offsets(
             start_lane_num=start_n,
             end_lane_num=end_n,
             lane_width=lane_w,
             end_boundary_offsets=end_offs_arr,
+            change_side=side,
+        )
+
+        # ---- apply lane-side shift to road end only --------------------
+        start_offsets = np.asarray(
+            apply_lane_side_shift(raw_start_offsets.tolist(), road_side), dtype=float
         )
 
         max_n = max(start_n, end_n)
@@ -248,6 +325,13 @@ class JunctionApproach(RoadSegment):
                     )
             center_pts = resampled
 
+        # ---- identify centreline boundary (road-end only) ---------------
+        cl_boundary_idx: int | None = None
+        if road_side == "right":
+            cl_boundary_idx = 0
+        elif road_side == "left":
+            cl_boundary_idx = boundary_num - 1
+
         # ---- generate boundaries and roadlines -------------------------
         boundary_points: list[np.ndarray] = []
         roadlines: list[RoadLine] = []
@@ -255,14 +339,17 @@ class JunctionApproach(RoadSegment):
         id_counter = id_offset
 
         for b_idx in range(boundary_num):
-            pts = _variable_offset_polyline(
+            pts = variable_offset_polyline(
                 centerline=center_pts,
                 start_offset=float(start_offsets[b_idx]),
                 end_offset=float(end_offsets[b_idx]),
             )
             boundary_points.append(pts)
 
-            marking_token = one_way_boundary_token(b_idx, boundary_num)
+            if b_idx == cl_boundary_idx and cl_token is not None:
+                marking_token = cl_token
+            else:
+                marking_token = one_way_boundary_token(b_idx, boundary_num)
 
             roadline = build_roadline_from_points(
                 id_=id_counter,
@@ -284,7 +371,7 @@ class JunctionApproach(RoadSegment):
         for lane_idx in range(max_n):
             left_pts = boundary_points[lane_idx]
             right_pts = boundary_points[lane_idx + 1]
-            role = _lane_role(
+            role = lane_role(
                 abs(start_offsets[lane_idx] - start_offsets[lane_idx + 1]),
                 abs(end_offsets[lane_idx] - end_offsets[lane_idx + 1]),
             )
@@ -331,11 +418,7 @@ class JunctionApproach(RoadSegment):
             speed_limit=speed,
         )
         exit_port = RoadPort(
-            point=end_pt,
-            heading=end_heading,
-            lane_num=end_n,
-            lane_width=lane_w,
-            speed_limit=speed,
+            point=end_pt, heading=end_heading, lane_num=end_n, lane_width=lane_w, speed_limit=speed
         )
 
         ports = {
@@ -358,13 +441,3 @@ class JunctionApproach(RoadSegment):
         return RoadModuleResult(
             lanes=lanes, roadlines=roadlines, ports=ports, id_counter=id_counter
         )
-
-
-def _lane_role(start_width: float, end_width: float) -> str:
-    """Classify a lane's role in the approach transition."""
-    eps = 1e-3
-    if start_width <= eps and end_width > eps:
-        return "added"
-    if start_width > eps and end_width <= eps:
-        return "dropped"
-    return "through"

--- a/tactics2d/map/generator/road_segment/lane_adapter.py
+++ b/tactics2d/map/generator/road_segment/lane_adapter.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from tactics2d.geometry import cumulative_s
 from tactics2d.map.element import Lane, RoadLine
 from tactics2d.map.generator.rules.lane_marking_rules import (
     one_way_boundary_token,
@@ -17,53 +16,14 @@ from tactics2d.map.generator.rules.module_types import RoadModuleResult, RoadPor
 
 from .element_builder import (
     add_ordered_lane_neighbors,
+    apply_lane_side_shift,
     build_lane_from_boundaries,
     build_roadline_from_points,
+    lane_role,
+    variable_offset_polyline,
 )
 from .reference_line import fit_reference_line
 from .road_segment import RoadSegment
-
-
-def _variable_offset_polyline(
-    centerline: np.ndarray, start_offset: float, end_offset: float
-) -> np.ndarray:
-    """Offset a polyline with a smoothly varying lateral offset.
-
-    The offset transitions from ``start_offset`` to ``end_offset`` via a
-    smoothstep (zero-slope Hermite cubic) function of arc length, producing
-    zero first derivative at both ends.
-
-    Args:
-        centerline: Centreline points with shape ``(N, 2)``.
-        start_offset: Lateral offset at the entry end in metres.
-            Positive = left of travel direction.
-        end_offset: Lateral offset at the exit end in metres.
-            Positive = left of travel direction.
-
-    Returns:
-        Offset polyline with shape ``(N, 2)``.
-    """
-    pts = np.asarray(centerline, dtype=float)
-
-    if len(pts) < 2:
-        return pts.copy()
-
-    cum = cumulative_s(pts)
-    total = cum[-1]
-    t = np.zeros(len(pts)) if total < 1e-9 else cum / total
-    t = t * t * (3.0 - 2.0 * t)
-
-    tangents = np.empty_like(pts)
-    tangents[0] = pts[1] - pts[0]
-    tangents[-1] = pts[-1] - pts[-2]
-    if len(pts) > 2:
-        tangents[1:-1] = pts[2:] - pts[:-2]
-    norms = np.linalg.norm(tangents, axis=1, keepdims=True)
-    tangents /= np.where(norms < 1e-9, 1.0, norms)
-    normals = np.column_stack([-tangents[:, 1], tangents[:, 0]])
-
-    offsets = float(start_offset) + (float(end_offset) - float(start_offset)) * t
-    return pts + offsets[:, None] * normals
 
 
 def _boundary_offsets_for_adapter(
@@ -105,28 +65,6 @@ def _boundary_offsets_for_adapter(
     return _uniform(max_lane_num), _padded(end_lane_num, change_side)
 
 
-def _lane_role(start_width: float, end_width: float) -> str:
-    """Classify a lane's role in the adapter transition.
-
-    Args:
-        start_width: Lane width at the entry end in metres.
-        end_width: Lane width at the exit end in metres.
-
-    Returns:
-        ``"added"`` if the lane opens from zero width, ``"dropped"`` if it
-        closes to zero, or ``"through"`` otherwise.
-    """
-    eps = 1e-3
-
-    if start_width <= eps and end_width > eps:
-        return "added"
-
-    if start_width > eps and end_width <= eps:
-        return "dropped"
-
-    return "through"
-
-
 class LaneAdapter(RoadSegment):
     """Same-direction lane-count adapter generator.
 
@@ -137,27 +75,53 @@ class LaneAdapter(RoadSegment):
     Attributes:
         change_side: Side where the lane is added or dropped. ``"right"`` means
             the rightmost lane changes; ``"left"`` means the leftmost lane changes.
+        lane_side: Which side of the centreline the lane group occupies.
+            ``"center"`` (default) places lanes symmetrically around the
+            centreline, matching :class:`OneWay` convention.  ``"right"`` pins
+            the leftmost boundary to the centreline so all lanes sit on the
+            right, matching :class:`TwoWay` forward convention.  ``"left"``
+            pins the rightmost boundary to the centreline (TwoWay backward
+            convention).
         step_size: Reference-line sampling interval in metres.
     """
 
-    def __init__(self, change_side: str = "right", step_size: float = 0.1) -> None:
+    def __init__(
+        self,
+        change_side: str = "right",
+        step_size: float = 0.1,
+        lane_side: str = "center",
+        centerline_marking_token: str | None = None,
+    ) -> None:
         """Initialise the generator.
 
         Args:
             change_side: Side where the lane count changes. Must be ``"left"``
                 or ``"right"``.
             step_size: Reference-line sampling interval in metres.
+            lane_side: Which side of the centreline all lanes sit on.
+                ``"center"`` (default), ``"left"``, or ``"right"``.
+            centerline_marking_token: When ``lane_side`` is ``"right"`` or
+                ``"left"``, the boundary pinned to the centreline continues
+                the TwoWay centre divider.  Pass a marking token string
+                (e.g. ``"solid_double_yellow"`` or the result of
+                :func:`~tactics2d.map.generator.rules.lane_marking_rules.two_way_centerline`)
+                to use that marking instead of the one-way edge rule.
+                Ignored when ``lane_side`` is ``"center"``.
 
         Raises:
             ValueError: If ``change_side`` is not ``"left"`` or ``"right"``,
-                or ``step_size <= 0``.
+                ``lane_side`` is invalid, or ``step_size <= 0``.
         """
         if change_side not in ("left", "right"):
             raise ValueError("change_side must be 'left' or 'right'.")
+        if lane_side not in ("center", "left", "right"):
+            raise ValueError("lane_side must be 'center', 'left', or 'right'.")
         if step_size <= 0.0:
             raise ValueError("step_size must be positive.")
         self.change_side = change_side
+        self.lane_side = lane_side
         self.step_size = step_size
+        self.centerline_marking_token = centerline_marking_token
 
     def build(
         self,
@@ -168,6 +132,9 @@ class LaneAdapter(RoadSegment):
         end_lane_num: int | None = None,
         lane_width: float | None = None,
         speed_limit: float | None = None,
+        start_lane_side: str | None = None,
+        end_lane_side: str | None = None,
+        centerline_marking_token: str | None = None,
         id_offset: int = 0,
     ) -> RoadModuleResult:
         """Build a lane-count adapter between two ports.
@@ -181,6 +148,13 @@ class LaneAdapter(RoadSegment):
                 ``end_port.lane_num``.
             lane_width: Lane width in metres. Defaults to ``start_port.lane_width``.
             speed_limit: Speed limit in km/h. Defaults to ``start_port.speed_limit``.
+            start_lane_side: Override ``self.lane_side`` for the start end.
+                ``None`` uses the generator default.
+            end_lane_side: Override ``self.lane_side`` for the end end.
+                ``None`` uses the generator default.
+            centerline_marking_token: Per-call override for
+                ``self.centerline_marking_token``.  ``None`` uses the generator
+                default.
             id_offset: First element id.
 
         Returns:
@@ -195,6 +169,13 @@ class LaneAdapter(RoadSegment):
         end_n = int(end_lane_num if end_lane_num is not None else end_port.lane_num)
         lane_w = float(lane_width if lane_width is not None else start_port.lane_width)
         speed = float(speed_limit if speed_limit is not None else start_port.speed_limit)
+        start_side = start_lane_side if start_lane_side is not None else self.lane_side
+        end_side = end_lane_side if end_lane_side is not None else self.lane_side
+        cl_token = (
+            centerline_marking_token
+            if centerline_marking_token is not None
+            else self.centerline_marking_token
+        )
 
         if start_n < 1:
             raise ValueError("start_lane_num must be >= 1.")
@@ -207,20 +188,33 @@ class LaneAdapter(RoadSegment):
                 "lane_adapter v1 only supports lane count difference of 1. "
                 "Use chained adapters, e.g. 2 -> 3 -> 4."
             )
+        for side in (start_side, end_side):
+            if side not in ("center", "left", "right"):
+                raise ValueError(f"lane_side must be 'center', 'left', or 'right', got {side!r}")
 
         center_pts = fit_reference_line(
             start_port.point, start_port.heading, end_port.point, end_port.heading, self.step_size
         )
 
-        start_offsets, end_offsets = _boundary_offsets_for_adapter(
+        raw_start_offsets, raw_end_offsets = _boundary_offsets_for_adapter(
             start_lane_num=start_n,
             end_lane_num=end_n,
             lane_width=lane_w,
             change_side=self.change_side,
         )
 
+        start_offsets = apply_lane_side_shift(raw_start_offsets, start_side)
+        end_offsets = apply_lane_side_shift(raw_end_offsets, end_side)
+
         max_lane_num = max(start_n, end_n)
         boundary_num = max_lane_num + 1
+
+        # ---- identify centreline boundary (if any) -----------------------
+        cl_boundary_idx: int | None = None
+        if start_side == end_side == "right":
+            cl_boundary_idx = 0
+        elif start_side == end_side == "left":
+            cl_boundary_idx = boundary_num - 1
 
         boundary_points: list[np.ndarray] = []
         roadlines: list[RoadLine] = []
@@ -228,14 +222,17 @@ class LaneAdapter(RoadSegment):
         id_counter = id_offset
 
         for boundary_idx in range(boundary_num):
-            pts = _variable_offset_polyline(
+            pts = variable_offset_polyline(
                 centerline=center_pts,
                 start_offset=start_offsets[boundary_idx],
                 end_offset=end_offsets[boundary_idx],
             )
             boundary_points.append(pts)
 
-            marking_token = one_way_boundary_token(boundary_idx, boundary_num)
+            if boundary_idx == cl_boundary_idx and cl_token is not None:
+                marking_token = cl_token
+            else:
+                marking_token = one_way_boundary_token(boundary_idx, boundary_num)
 
             roadline = build_roadline_from_points(
                 id_=id_counter,
@@ -261,7 +258,7 @@ class LaneAdapter(RoadSegment):
 
             start_width = abs(start_offsets[lane_idx] - start_offsets[lane_idx + 1])
             end_width = abs(end_offsets[lane_idx] - end_offsets[lane_idx + 1])
-            role = _lane_role(start_width, end_width)
+            role = lane_role(start_width, end_width)
 
             lane = build_lane_from_boundaries(
                 id_=id_counter,

--- a/tests/test_map_generator.py
+++ b/tests/test_map_generator.py
@@ -26,6 +26,7 @@ from tactics2d.map.generator.road_segment import (
     ExitRamp,
     Fork,
     Intersection,
+    JunctionApproach,
     LaneAdapter,
     Merge,
     OneWay,
@@ -263,6 +264,126 @@ def test_lane_adapter(runtime_dir, start_n: int, end_n: int, change_side: str) -
     assert result.ports["exit"].lane_num == end_n
     assert len(result.lanes) == max_n
     assert len(result.roadlines) == max_n + 1
+
+
+def _junction_approach_centerline(start, heading, length, step_size=0.1):
+    """Generate a straight centreline for JunctionApproach tests."""
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    return sample_centerline(start, heading, length, curvature=0.0, step_size=step_size)
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "start_n,end_n,change_side,taper_len",
+    [
+        (2, 3, "right", 30.0),
+        (3, 2, "right", 30.0),
+        (2, 3, "left", 30.0),
+        (3, 2, "left", 30.0),
+        (2, 2, "both", 30.0),
+        (1, 3, "both", 40.0),
+        (3, 1, "both", 40.0),
+    ],
+    ids=["expand_right", "reduce_right", "expand_left", "reduce_left", "no_change", "1to3", "3to1"],
+)
+def test_junction_approach(
+    runtime_dir, start_n: int, end_n: int, change_side: str, taper_len: float
+) -> None:
+    """Visual smoke test: renders each transition scenario for manual inspection.
+
+    Run with ``TACTICS2D_RENDER_MAPS=1 pytest ...`` to generate PNGs under
+    ``build/test_maps/``.
+    """
+    map_ = Map(name=f"junction_approach_{start_n}to{end_n}_{change_side}")
+    cl = _junction_approach_centerline(np.array([0.0, 0.0]), 0.0, taper_len)
+    result = JunctionApproach(change_side=change_side).build(
+        centerline=cl,
+        start_lane_num=start_n,
+        end_lane_num=end_n,
+        end_boundary_offsets=np.array([end_n / 2.0 * 3.5 - i * 3.5 for i in range(end_n + 1)]),
+        id_offset=0,
+    )
+    _add_result(map_, result)
+    _render(map_, runtime_dir / f"junction_approach_{start_n}to{end_n}_{change_side}.png")
+    max_n = max(start_n, end_n)
+    assert "entry" in result.ports
+    assert "exit" in result.ports
+    assert result.ports["entry"].lane_num == start_n
+    assert result.ports["exit"].lane_num == end_n
+    assert len(result.lanes) == max_n
+    assert len(result.roadlines) == max_n + 1
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "taper_len,expect_warning", [(30.0, False), (3.0, True)], ids=["adequate_length", "too_short"]
+)
+def test_junction_approach_taper_length(caplog, taper_len: float, expect_warning: bool) -> None:
+    """Short centreline should emit a warning about taper stiffness."""
+    caplog.set_level(
+        logging.WARNING, logger="tactics2d.map.generator.road_segment.junction_approach"
+    )
+    cl = _junction_approach_centerline(np.array([0.0, 0.0]), 0.0, taper_len)
+    JunctionApproach().build(
+        centerline=cl,
+        start_lane_num=2,
+        end_lane_num=3,
+        end_boundary_offsets=np.array([5.25, 3.5, 1.75, 0.0]),
+        id_offset=0,
+    )
+    if expect_warning:
+        assert any("shorter than recommended" in rec.message for rec in caplog.records)
+    else:
+        assert not any("shorter than recommended" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.map_generator
+def test_junction_approach_invalid_args() -> None:
+    """Invalid arguments should raise ValueError."""
+    cl = _junction_approach_centerline(np.array([0.0, 0.0]), 0.0, 20.0)
+
+    with pytest.raises(ValueError, match="start_lane_num must be >= 1"):
+        JunctionApproach().build(
+            centerline=cl,
+            start_lane_num=0,
+            end_lane_num=2,
+            end_boundary_offsets=np.array([3.5, 1.75, 0.0]),
+            id_offset=0,
+        )
+    with pytest.raises(ValueError, match="end_lane_num must be >= 1"):
+        JunctionApproach().build(
+            centerline=cl,
+            start_lane_num=2,
+            end_lane_num=0,
+            end_boundary_offsets=np.array([0.0]),
+            id_offset=0,
+        )
+    with pytest.raises(ValueError, match="lane_width must be positive"):
+        JunctionApproach().build(
+            centerline=cl,
+            start_lane_num=2,
+            end_lane_num=2,
+            end_boundary_offsets=np.array([3.5, 1.75, 0.0]),
+            lane_width=0.0,
+            id_offset=0,
+        )
+    with pytest.raises(ValueError, match="end_boundary_offsets must have"):
+        JunctionApproach().build(
+            centerline=cl,
+            start_lane_num=2,
+            end_lane_num=2,
+            end_boundary_offsets=np.array([3.5, 0.0]),  # should be 3 elements
+            id_offset=0,
+        )
+    with pytest.raises(ValueError, match="centreline must have at least 2 points"):
+        JunctionApproach().build(
+            centerline=np.array([[0.0, 0.0]]),
+            start_lane_num=2,
+            end_lane_num=2,
+            end_boundary_offsets=np.array([3.5, 1.75, 0.0]),
+            id_offset=0,
+        )
 
 
 @pytest.mark.map_generator
@@ -660,21 +781,8 @@ def test_ramp_urban_left_side_raises() -> None:
 @pytest.mark.map_generator
 @pytest.mark.parametrize(
     "arm_dicts,match",
-    [
-        (
-            [{"heading": h, "lane_num": 2} for h in [0.0, np.pi / 2]],
-            "intersection requires 3 or 4 arms",
-        ),
-        (
-            [
-                {"heading": h, "lane_num": 2}
-                for h in [0.0, np.pi / 2, np.pi, 3 * np.pi / 2, np.pi / 4]
-            ],
-            "intersection requires 3 or 4 arms",
-        ),
-        ([{"heading": h, "lane_num": 0} for h in [0.0, np.pi / 2, np.pi]], "lane_num must be"),
-    ],
-    ids=["too_few_arms", "too_many_arms", "zero_lane_num"],
+    [([{"heading": h, "lane_num": 0} for h in [0.0, np.pi / 2, np.pi]], "lane_num must be")],
+    ids=["zero_lane_num"],
 )
 def test_intersection_invalid_arms(arm_dicts: list, match: str) -> None:
     with pytest.raises(ValueError, match=match):
@@ -715,3 +823,506 @@ def test_intersection_no_id_collision() -> None:
     ids_2 = {e.id_ for e in [*result_2.lanes, *result_2.roadlines, *result_2.junctions]}
     assert len(ids_1 & ids_2) == 0
     assert result_2.id_counter > result_1.id_counter
+
+
+# ---------------------------------------------------------------------------
+# JunctionApproach curvature and integration tests
+# ---------------------------------------------------------------------------
+
+
+def _compute_curvature(pts: np.ndarray) -> np.ndarray:
+    """Discrete signed curvature along a polyline using finite differences.
+
+    Args:
+        pts: Points with shape ``(N, 2)``.
+
+    Returns:
+        Curvature array of length ``N``.  Boundary points use one-sided
+        differences; interior points use central differences.
+    """
+    if len(pts) < 3:
+        return np.zeros(len(pts))
+
+    d1 = np.diff(pts, axis=0)  # first differences, shape (N-1, 2)
+    ds = np.linalg.norm(d1, axis=1)
+    ds = np.where(ds < 1e-12, 1e-12, ds)
+    tangents = d1 / ds[:, None]  # shape (N-1, 2)
+
+    # second differences via tangent differences at midpoints
+    d_tangents = np.diff(tangents, axis=0)  # shape (N-2, 2)
+    mid_ds = (ds[:-1] + ds[1:]) / 2.0  # shape (N-2,)
+    mid_ds = np.where(mid_ds < 1e-12, 1e-12, mid_ds)
+    curvature = np.zeros(len(pts))
+    curvature[1:-1] = np.linalg.norm(d_tangents, axis=1) / mid_ds
+
+    # one-sided for endpoints
+    curvature[0] = curvature[1]
+    curvature[-1] = curvature[-2]
+
+    return curvature
+
+
+@pytest.mark.map_generator
+def test_junction_approach_curvature_endpoints() -> None:
+    """Quintic smoothstep boundaries must have near-zero curvature at both ends.
+
+    This is the key numerical guarantee that fixes the "stiff taper" issue:
+    cubic smoothstep produces curvature jumps at endpoints; quintic eliminates
+    them.  We verify by generating a taper on a curved centreline with a
+    lane-count change and checking that every boundary's curvature decays to
+    near zero within a few samples of each endpoint.
+    """
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    # curved centreline — a gentle left-turning arc
+    cl = sample_centerline(np.array([0.0, 0.0]), heading=0.0, length=40.0, curvature=0.005)
+    end_n = 3
+    end_offs = np.array([end_n / 2.0 * 3.5 - i * 3.5 for i in range(end_n + 1)])
+
+    result = JunctionApproach(change_side="both").build(
+        centerline=cl,
+        start_lane_num=2,
+        end_lane_num=end_n,
+        end_boundary_offsets=end_offs,
+        lane_width=3.5,
+        id_offset=0,
+    )
+
+    # extract boundary polylines
+    for rl in result.roadlines:
+        pts = np.asarray(rl.geometry.coords)
+        if len(pts) < 5:
+            continue  # skip very short boundaries
+        kappa = _compute_curvature(pts)
+        # first and last 3 samples should be small (< 50% of max curvature)
+        max_k = max(float(np.max(np.abs(kappa))), 1e-6)
+        entry_curv = np.abs(kappa[:3]).max()
+        exit_curv = np.abs(kappa[-3:]).max()
+        assert (
+            entry_curv / max_k < 0.5
+        ), f"high entry curvature: {entry_curv:.4f} vs max {max_k:.4f}"
+        assert exit_curv / max_k < 0.5, f"high exit curvature: {exit_curv:.4f} vs max {max_k:.4f}"
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "change_side,taper_len,label",
+    [
+        ("both", 20.0, "curved_both"),
+        ("left", 20.0, "curved_left"),
+        ("right", 20.0, "curved_right"),
+        ("both", 5.0, "short_both"),
+    ],
+    ids=["curved_both", "curved_left", "curved_right", "short_both"],
+)
+def test_junction_approach_complex(
+    runtime_dir, change_side: str, taper_len: float, label: str
+) -> None:
+    """Curved centreline + non-uniform port boundaries — realistic junction approach.
+
+    This exercises the three fixes together:
+    - Quintic smoothstep on a curved reference line
+    - change_side controlling asymmetric lane addition
+    - min_taper_length warning for the "short" variant
+
+    The junction port simulates a 3-lane arm where the left-turn lane is
+    narrower (3.0 m) and the through/right lanes are 3.5 m.
+    """
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    # curved approach at 30° heading
+    cl = sample_centerline(
+        np.array([0.0, 0.0]), heading=np.deg2rad(30), length=taper_len, curvature=0.008
+    )
+    # non-uniform port boundaries: [leftmost=5.25, 2.75, 0.0, -3.5] (rightmost)
+    end_offsets = np.array([5.25, 2.75, 0.0, -3.5])
+
+    map_ = Map(name=f"junction_approach_{label}")
+    result = JunctionApproach(change_side=change_side).build(
+        centerline=cl,
+        start_lane_num=2,
+        end_lane_num=3,
+        end_boundary_offsets=end_offsets,
+        lane_width=3.5,
+        id_offset=0,
+    )
+    _add_result(map_, result)
+    _render(map_, runtime_dir / f"junction_approach_{label}.png")
+
+    assert len(result.lanes) == 3
+    assert len(result.roadlines) == 4
+    # all lanes must have valid line references
+    _assert_lane_line_ids_resolved(result)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 verification — lane matching with change_side
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "start_n,end_n,change_side,expected_roles",
+    [
+        # 2→3: one lane added
+        (2, 3, "left", ["added", "through", "through"]),
+        (2, 3, "right", ["through", "through", "added"]),
+        # 3→2: one lane dropped
+        (3, 2, "left", ["dropped", "through", "through"]),
+        (3, 2, "right", ["through", "through", "dropped"]),
+        # 2→4: two lanes added on the specified side
+        (2, 4, "left", ["added", "added", "through", "through"]),
+        (2, 4, "right", ["through", "through", "added", "added"]),
+        # 4→2: two lanes dropped on the specified side
+        (4, 2, "left", ["dropped", "dropped", "through", "through"]),
+        (4, 2, "right", ["through", "through", "dropped", "dropped"]),
+        # no change — all through
+        (2, 2, "left", ["through", "through"]),
+        (2, 2, "right", ["through", "through"]),
+    ],
+    ids=[
+        "expand_left_2to3",
+        "expand_right_2to3",
+        "reduce_left_3to2",
+        "reduce_right_3to2",
+        "expand_left_2to4",
+        "expand_right_2to4",
+        "reduce_left_4to2",
+        "reduce_right_4to2",
+        "no_change_left",
+        "no_change_right",
+    ],
+)
+def test_junction_approach_lane_roles(
+    start_n: int, end_n: int, change_side: str, expected_roles: list[str]
+) -> None:
+    """Verify change_side correctly positions added/dropped lanes.
+
+    This is the direct validation of bug 2 (lane matching).  Each lane's
+    ``custom_tags["lane_role"]`` must match the expected side-preference.
+    """
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    cl = sample_centerline(np.array([0.0, 0.0]), 0.0, 30.0)
+    end_offs = np.array([end_n / 2.0 * 3.5 - i * 3.5 for i in range(end_n + 1)])
+
+    result = JunctionApproach(change_side=change_side).build(
+        centerline=cl,
+        start_lane_num=start_n,
+        end_lane_num=end_n,
+        end_boundary_offsets=end_offs,
+        id_offset=0,
+    )
+
+    actual_roles = [lane.custom_tags.get("lane_role", "?") for lane in result.lanes]
+    assert actual_roles == expected_roles, (
+        f"change_side={change_side!r}, {start_n}→{end_n}: "
+        f"expected {expected_roles}, got {actual_roles}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 verification — roadline deduplication
+# ---------------------------------------------------------------------------
+
+
+def _make_dummy_roadline(id_: str, start, end, step_size=0.1):
+    """Create a RoadLine with a straight segment from *start* to *end*."""
+    from shapely.geometry import LineString
+
+    from tactics2d.map.element import RoadLine
+
+    return RoadLine(
+        id_=str(id_),
+        geometry=LineString([tuple(start), tuple(end)]),
+        type_="virtual",
+        subtype="solid",
+        color="white",
+    )
+
+
+@pytest.mark.map_generator
+def test_deduplicate_roadlines_merges_identical() -> None:
+    """Two roadlines with nearly identical geometry should be merged."""
+    from shapely.geometry import LineString
+
+    from tactics2d.map.element import Lane, RoadLine
+    from tactics2d.map.generator.road_segment.element_builder import deduplicate_roadlines
+
+    start = np.array([0.0, 0.0])
+    end = np.array([10.0, 0.0])
+
+    rl_a = _make_dummy_roadline("a", start, end)
+    rl_b = _make_dummy_roadline("b", start + 0.01, end + 0.01)  # nearly identical
+    rl_c = _make_dummy_roadline("c", start, np.array([10.0, 5.0]))  # different end
+
+    # Lane that references both duplicates
+    lane = Lane(
+        id_="lane_1",
+        left_side=LineString([(0.0, 1.75), (10.0, 1.75)]),
+        right_side=LineString([(0.0, -1.75), (10.0, -1.75)]),
+        line_ids={"left": ["a"], "right": ["b", "c"]},
+    )
+
+    roadlines = [rl_a, rl_b, rl_c]
+    deduped, updated_lanes = deduplicate_roadlines(roadlines, [lane], step_size=0.1)
+
+    # rl_b should be merged into rl_a
+    assert len(deduped) < len(roadlines), "expected at least one roadline to be merged"
+    remaining_ids = {rl.id_ for rl in deduped}
+    assert "a" in remaining_ids, "kept roadline 'a' should remain"
+    assert "b" not in remaining_ids, "duplicate roadline 'b' should be removed"
+    assert "c" in remaining_ids, "non-duplicate roadline 'c' should remain"
+
+    # Lane references should be updated
+    left_ids = updated_lanes[0].line_ids["left"]
+    right_ids = updated_lanes[0].line_ids["right"]
+    assert left_ids == ["a"], f"left refs should be ['a'], got {left_ids}"
+    assert "b" not in right_ids, f"'b' should not appear in right refs: {right_ids}"
+    assert "a" in right_ids, f"'a' should replace 'b' in right refs: {right_ids}"
+    assert "c" in right_ids, f"'c' should be kept in right refs: {right_ids}"
+
+
+@pytest.mark.map_generator
+def test_deduplicate_roadlines_no_false_positive() -> None:
+    """Roadlines with clearly different geometry should NOT be merged."""
+    from shapely.geometry import LineString
+
+    from tactics2d.map.element import Lane, RoadLine
+    from tactics2d.map.generator.road_segment.element_builder import deduplicate_roadlines
+
+    rl_a = _make_dummy_roadline("a", np.array([0.0, 0.0]), np.array([10.0, 0.0]))
+    rl_b = _make_dummy_roadline("b", np.array([0.0, 0.0]), np.array([10.0, 5.0]))  # different
+    rl_c = _make_dummy_roadline("c", np.array([5.0, 0.0]), np.array([15.0, 0.0]))  # shifted
+    # Same endpoints and length within the old tolerance, but not the same path.
+    rl_d = RoadLine(
+        id_="d",
+        geometry=LineString([(0.0, 0.0), (5.0, 1.0), (10.0, 0.0)]),
+        type_="virtual",
+        subtype="solid",
+        color="white",
+    )
+
+    lane = Lane(
+        id_="lane_1",
+        left_side=LineString([(0.0, 1.0), (10.0, 1.0)]),
+        right_side=LineString([(0.0, -1.0), (10.0, -1.0)]),
+        line_ids={"left": ["a"], "right": ["b", "c"]},
+    )
+
+    roadlines = [rl_a, rl_b, rl_c, rl_d]
+    deduped, _ = deduplicate_roadlines(roadlines, [lane], step_size=0.1)
+
+    assert len(deduped) == 4, "no roadlines should be merged — all are distinct"
+
+
+# ---------------------------------------------------------------------------
+# LaneAdapter lane_side parameter tests
+# ---------------------------------------------------------------------------
+
+
+def _adapter_lane_centers(result: RoadModuleResult) -> list[float]:
+    """Return lane centre offsets at the start end (midpoint of left/right boundaries)."""
+    centers: list[float] = []
+    for lane in result.lanes:
+        left_pts = np.asarray(lane.left_side.coords)
+        right_pts = np.asarray(lane.right_side.coords)
+        # measure offset at the first point of each boundary
+        dx_l = left_pts[0, 0] - left_pts[-1, 0]
+        dy_l = left_pts[0, 1] - left_pts[-1, 1]
+        dx_r = right_pts[0, 0] - right_pts[-1, 0]
+        dy_r = right_pts[0, 1] - right_pts[-1, 1]
+        # lateral offset at start ≈ perpendicular distance from centreline start
+        # For a horizontal road heading=0, y is the lateral coordinate
+        start_y = (left_pts[0, 1] + right_pts[0, 1]) / 2.0
+        centers.append(round(start_y, 6))
+    return centers
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "lane_side,start_n,end_n,expected_signs",
+    [
+        ("center", 2, 3, ["mixed", "mixed", "mixed"]),
+        ("right", 2, 3, ["right", "right", "right"]),
+        ("left", 2, 3, ["left", "left", "left"]),
+        ("right", 3, 2, ["right", "right", "right"]),
+        ("left", 3, 2, ["left", "left", "left"]),
+        ("center", 2, 2, ["mixed", "mixed"]),
+        ("right", 2, 2, ["right", "right"]),
+    ],
+    ids=[
+        "center_2to3",
+        "right_2to3",
+        "left_2to3",
+        "right_3to2",
+        "left_3to2",
+        "center_no_change",
+        "right_no_change",
+    ],
+)
+def test_lane_adapter_lane_side_position(
+    lane_side: str, start_n: int, end_n: int, expected_signs: list[str]
+) -> None:
+    """LaneAdapter lane_side must correctly position lanes relative to centreline.
+
+    For a straight, horizontal (heading=0) adapter, the centreline is on y=0.
+    "right" means all lane centre y values are negative;
+    "left" means all are positive;
+    "center" means lanes straddle both sides.
+
+    Zero-width ("added" / "dropped") lanes may have a centre at y=0; they are
+    excluded from the sign check because the lane does not yet exist at the
+    collapsed end.
+    """
+    result = LaneAdapter(change_side="right", lane_side=lane_side).build(
+        _make_port(0.0, 0.0, 0.0, start_n),
+        _make_port(30.0, 0.0, 0.0, end_n),
+        start_lane_num=start_n,
+        end_lane_num=end_n,
+        id_offset=0,
+    )
+
+    assert len(result.lanes) == max(start_n, end_n)
+
+    for lane, expected in zip(result.lanes, expected_signs):
+        left_y = np.asarray(lane.left_side.coords)[0, 1]
+        right_y = np.asarray(lane.right_side.coords)[0, 1]
+        center_y = (left_y + right_y) / 2.0
+        width = abs(left_y - right_y)
+
+        # collapsed (zero-width) lanes may sit at y=0 — skip sign check
+        if width < 1e-6:
+            continue
+
+        if expected == "right":
+            assert center_y < -1e-6, f"lane {lane.id_} centre {center_y} should be < 0 (right)"
+            assert left_y <= 1e-6, f"lane {lane.id_} left boundary {left_y} should be ≤ 0"
+        elif expected == "left":
+            assert center_y > 1e-6, f"lane {lane.id_} centre {center_y} should be > 0 (left)"
+            assert right_y >= -1e-6, f"lane {lane.id_} right boundary {right_y} should be ≥ 0"
+        # "mixed" — no assertion, symmetric distribution
+
+
+@pytest.mark.map_generator
+def test_lane_adapter_per_end_lane_side() -> None:
+    """Per-end lane_side overrides allow asymmetric configurations.
+
+    TwoWay forward → intersection: start_side="right" (road), end_side="center"
+    (intersection).
+    """
+    result = LaneAdapter(change_side="right", lane_side="right").build(
+        _make_port(0.0, 0.0, 0.0, 2),
+        _make_port(30.0, 0.0, 0.0, 3),
+        start_lane_num=2,
+        end_lane_num=3,
+        end_lane_side="center",  # intersection side stays symmetric
+        id_offset=0,
+    )
+
+    # start end (road side): all lanes on the right
+    for lane in result.lanes:
+        left_start_y = np.asarray(lane.left_side.coords)[0, 1]
+        right_start_y = np.asarray(lane.right_side.coords)[0, 1]
+        assert left_start_y <= 1e-6, f"start: lane {lane.id_} left should be ≤ 0"
+
+    # end end (intersection side): centred
+    end_centers = []
+    for lane in result.lanes:
+        left_end_y = np.asarray(lane.left_side.coords)[-1, 1]
+        right_end_y = np.asarray(lane.right_side.coords)[-1, 1]
+        end_centers.append((left_end_y + right_end_y) / 2.0)
+
+    # after shifting at start only, the end should still be symmetric
+    assert any(c > 1e-6 for c in end_centers), "at least one lane centre should be > 0"
+    assert any(c < -1e-6 for c in end_centers), "at least one lane centre should be < 0"
+
+
+@pytest.mark.map_generator
+def test_junction_approach_lane_side() -> None:
+    """JunctionApproach lane_side shifts road-end lanes while keeping junction end fixed."""
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    cl = sample_centerline(np.array([0.0, 0.0]), 0.0, 30.0)
+    end_n = 3
+    end_offs = np.array([end_n / 2.0 * 3.5 - i * 3.5 for i in range(end_n + 1)])
+
+    result = JunctionApproach(change_side="both", lane_side="right").build(
+        centerline=cl,
+        start_lane_num=2,
+        end_lane_num=end_n,
+        end_boundary_offsets=end_offs,
+        id_offset=0,
+    )
+
+    # road-end (start): all lanes on the right side
+    for lane in result.lanes:
+        left_start_y = np.asarray(lane.left_side.coords)[0, 1]
+        right_start_y = np.asarray(lane.right_side.coords)[0, 1]
+        center_start_y = (left_start_y + right_start_y) / 2.0
+        assert (
+            center_start_y < -1e-6 or abs(center_start_y) < 1e-6
+        ), f"road-end lane centre {center_start_y} should be ≤ 0 (right side)"
+
+    # junction end keeps the port offsets
+    _assert_lane_line_ids_resolved(result)
+
+
+@pytest.mark.map_generator
+@pytest.mark.parametrize(
+    "init_kwargs,match", [({"lane_side": "diagonal"}, "lane_side must be")], ids=["bad_lane_side"]
+)
+def test_lane_adapter_invalid_lane_side(init_kwargs: dict, match: str) -> None:
+    """Invalid lane_side must raise ValueError."""
+    with pytest.raises(ValueError, match=match):
+        LaneAdapter(**init_kwargs)
+
+
+@pytest.mark.map_generator
+def test_lane_adapter_positional_step_size_compatibility() -> None:
+    """The pre-existing positional ``step_size`` argument remains supported."""
+    adapter = LaneAdapter("left", 0.5)
+    assert adapter.change_side == "left"
+    assert adapter.step_size == pytest.approx(0.5)
+    assert adapter.lane_side == "center"
+
+
+@pytest.mark.map_generator
+def test_junction_approach_lane_side_invalid() -> None:
+    """Invalid lane_side in JunctionApproach build() must raise ValueError."""
+    from tactics2d.map.generator.road_segment.reference_line import sample_centerline
+
+    cl = sample_centerline(np.array([0.0, 0.0]), 0.0, 20.0)
+    with pytest.raises(ValueError, match="lane_side must be"):
+        JunctionApproach().build(
+            centerline=cl,
+            start_lane_num=2,
+            end_lane_num=2,
+            end_boundary_offsets=np.array([3.5, 1.75, 0.0]),
+            start_lane_side="diagonal",
+            id_offset=0,
+        )
+
+
+@pytest.mark.map_generator
+def test_lane_adapter_centerline_marking():
+    """When centerline_marking_token is set, the centreline boundary uses it."""
+    result = LaneAdapter(
+        change_side="right", lane_side="right", centerline_marking_token="solid_double_yellow"
+    ).build(
+        _make_port(0.0, 0.0, 0.0, 2),
+        _make_port(30.0, 0.0, 0.0, 3),
+        start_lane_num=2,
+        end_lane_num=3,
+        id_offset=0,
+    )
+
+    # boundary 0 (leftmost) should use the centreline marking
+    rl0 = result.roadlines[0]
+    assert rl0.custom_tags.get("marking_token") == "solid_double_yellow"
+    assert rl0.custom_tags.get("marking_role") == "centerline"
+    assert rl0.color == "yellow"
+
+    # boundary 1 and beyond should use standard one-way markings
+    rl1 = result.roadlines[1]
+    assert rl1.custom_tags.get("marking_token") != "solid_double_yellow"


### PR DESCRIPTION
## Summary

Refine shared road-taper utilities for `dev-road`, improving lane-count transitions and junction approaches.

## Motivation and Context

Avoid duplicated taper logic between `LaneAdapter` and `JunctionApproach`, make lane-side handling consistent, and prevent incorrect roadline deduplication.

## Changes (Mandatory)

- Move shared taper geometry, lane-role, lane-side shift, and roadline deduplication utilities into `element_builder.py`.
- Update `LaneAdapter` to support lane-side placement and centerline marking while preserving positional `step_size` compatibility.
- Update `JunctionApproach` to reuse shared utilities and validate approach boundary/centerline inputs.
- Simplify tests by removing intersection/roundabout integration scenarios and adding taper, compatibility, and deduplication regression coverage.

Modified files:

- `tactics2d/map/generator/road_segment/element_builder.py`
- `tactics2d/map/generator/road_segment/junction_approach.py`
- `tactics2d/map/generator/road_segment/lane_adapter.py`
- `tests/test_map_generator.py`

## Testing (Mandatory)

- [x] `pre-commit run --files ...` passed
- [x] `pytest tests/test_map_generator.py -q` passed (`87 passed`)
- [x] Google-style English docstrings and formatting checked

Result summary: All local checks passed.

## Reviewer Checklist (Author)

- [x] PR title follows project style
- [x] PR title follows gitmoji recommendation
- [ ] Appropriate labels have been applied
- [ ] Reviewer(s) have been assigned
- [x] Code documentation/docstrings in this PR are written in English
- [x] This PR is ready for review

Suggested title: `♻️ Refactor: share road taper utilities`

Suggested labels: `refactor`, `pytest`, `area: python`
