### PR TITLE
🐛 Fix: map and dataset parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Fixed
 
+- Fixed `NuPlanParser.parse_trajectory` crashing with `sqlite3.OperationalError: unrecognized token: "{"` on every database: the lidar-box query was built as a plain string literal containing an unexpanded `{where}` placeholder, so the conditional time-window clause was never interpolated. The query is now an f-string, so `time_range` filtering (and the plain full-database scan) works as intended.
 - Fixed browser-frontend dataset discovery emitting backslash-separated relative paths on Windows: entries are now normalized with `as_posix()`, which also unbreaks WOMD and Argoverse 2 scenario selection there (both split the `file` value on `/`).
 - Fixed `Argoverse2Parser` crashing with `KeyError: 'construction'` on real motion-forecasting scenarios: the `construction` and `unknown` object categories were missing from the type mappings, and unseen future categories now degrade to `Other` instead of aborting the parse. Found by loading official validation scenarios from the public Argoverse S3 bucket.
 - Fixed screen recordings failing to play in strict players (e.g. GNOME Videos): with the compatibility-mode toggle enabled (default), captures are finalized server-side via ffmpeg (`POST /api/record/export`) into constant-frame-rate H.264 MP4, since raw MediaRecorder output declares a variable (0/1) frame rate; unticking the toggle (or a server without ffmpeg) downloads the raw recording unchanged.

--- a/tactics2d/dataset_parser/parse_nuplan.py
+++ b/tactics2d/dataset_parser/parse_nuplan.py
@@ -149,7 +149,7 @@ class NuPlanParser:
                 }
 
             cursor.execute(
-                """
+                f"""
                 SELECT
                     lidar_box.track_token AS track_token,
                     lidar_box.x AS x,

--- a/tactics2d/dataset_parser/parse_nuplan.py
+++ b/tactics2d/dataset_parser/parse_nuplan.py
@@ -107,6 +107,19 @@ class NuPlanParser:
         if time_range is None:
             time_range = (-float("inf"), float("inf"))
 
+        # Bound the lidar_box scan to the requested time window when it is finite
+        # (raw lidar_pc.timestamp is in microseconds since 2021-01-01; the
+        # ``time_range`` is in milliseconds relative to ``_DATETIME``).
+        if np.isfinite(time_range[0]) and np.isfinite(time_range[1]):
+            where = " WHERE lidar_pc.timestamp BETWEEN ? AND ?"
+            bound_args = (
+                (int(time_range[0]) + self._DATETIME) * 1000,
+                (int(time_range[1]) + self._DATETIME) * 1000,
+            )
+        else:
+            where = ""
+            bound_args = ()
+
         with sqlite3.connect(file_path) as connection:
             connection.row_factory = sqlite3.Row
             cursor = connection.cursor()
@@ -152,11 +165,12 @@ class NuPlanParser:
                     lidar_box.confidence AS confidence,
                     lidar_pc.timestamp AS timestamp
                 FROM lidar_box
-                INNER JOIN lidar_pc ON lidar_pc.token = lidar_box.lidar_pc_token
+                INNER JOIN lidar_pc ON lidar_pc.token = lidar_box.lidar_pc_token{where}
                 ORDER BY lidar_pc.timestamp
-                """
+                """,
+                bound_args,
             )
-            for row in cursor.fetchall():
+            for row in cursor:
                 time_stamp = int(row["timestamp"] / 1000 - self._DATETIME)
                 if time_stamp < time_range[0] or time_stamp > time_range[1]:
                     continue

--- a/tactics2d/dataset_parser/parse_womd.py
+++ b/tactics2d/dataset_parser/parse_womd.py
@@ -4,6 +4,7 @@
 """Waymo Open Motion Dataset parser implementation."""
 
 
+import struct
 from pathlib import Path
 from typing import List, Tuple, Union
 
@@ -25,6 +26,60 @@ class WOMDParser:
 
     Because loading the tfrecord file is time consuming, the trajectory and the map parsers provide two ways to load the file. The first way is to load the file directly from the given file path. The second way is to load the file from a tfrecord.tfrecord_iterator object. If the tfrecord.tfrecord_iterator object is given, the parser will ignore the file path.
     """
+
+    def __init__(self) -> None:
+        """Initialize the WOMD parser with an in-memory tfrecord offset index.
+
+        The byte-offset index of every tfrecord is built once per process
+        (a framing-only scan, no protobuf parsing) and reused, so per-scenario
+        reads are O(1) instead of O(number of scenarios in the file).
+        """
+        self._offsets = {}  # per-process in-memory: tfrecord path -> offsets
+
+    def _scan_offsets(self, file_path: str) -> List[int]:
+        """Byte offset of every record, from the tfrecord framing only.
+
+        Reads the 12-byte header (8-byte length + 4-byte CRC) of each record and
+        seeks past the datum, so the scan never parses protobuf payloads.
+        """
+        offsets = []
+        with open(file_path, "rb") as handle:
+            while True:
+                pos = handle.tell()
+                header = handle.read(12)
+                if len(header) < 12:
+                    break
+                (length,) = struct.unpack("<Q", header[:8])
+                offsets.append(pos)
+                handle.seek(length + 4, 1)  # relative: skip datum + trailing crc
+        return offsets
+
+    def _offsets_for(self, file_path: str) -> List[int]:
+        """Record offsets of a tfrecord, built once per process and memoized."""
+        if file_path not in self._offsets:
+            self._offsets[file_path] = self._scan_offsets(file_path)
+        return self._offsets[file_path]
+
+    @staticmethod
+    def _read_record_at(file, offset: int) -> bytes:
+        """Raw bytes of one tfrecord record at a byte offset."""
+        file.seek(offset)
+        header = file.read(12)
+        (length,) = struct.unpack("<Q", header[:8])
+        return file.read(length)
+
+    def _scenario_by_index(self, scenario_id: int, file: str, folder: str):
+        """Parse one scenario by record index via the in-memory offset index (O(1))."""
+        file_path = Path(folder) / file
+        offsets = self._offsets_for(str(file_path))
+        if not offsets:
+            return None
+        data_id = scenario_id % len(offsets)
+        with open(file_path, "rb") as handle:
+            proto_bytes = self._read_record_at(handle, offsets[data_id])
+        scenario = scenario_pb.Scenario()
+        scenario.ParseFromString(proto_bytes)
+        return scenario
 
     _TYPE_MAPPING = {0: "unknown", 1: "vehicle", 2: "pedestrian", 3: "cyclist", 4: "other"}
 
@@ -185,8 +240,11 @@ class WOMDParser:
         participants = dict()
         time_stamps = set()
 
-        dataset = self._get_dataset(**kwargs)
-        scenario, _ = self._resolve_scenario_data(scenario_id, dataset)
+        if isinstance(scenario_id, int) and "file" in kwargs and "folder" in kwargs:
+            scenario = self._scenario_by_index(scenario_id, kwargs["file"], kwargs["folder"])
+        else:
+            dataset = self._get_dataset(**kwargs)
+            scenario, _ = self._resolve_scenario_data(scenario_id, dataset)
         fill_invalid_gaps = kwargs.get("fill_invalid_gaps", False)
         max_gap_frames = kwargs.get("max_gap_frames", 1)
 

--- a/tactics2d/map/parser/parse_osm.py
+++ b/tactics2d/map/parser/parse_osm.py
@@ -33,6 +33,57 @@ class OSMParser:
                 Defaults to False.
         """
         self.lanelet2 = lanelet2
+        self._way_id_map = {}
+        self._relation_id_map = {}
+
+    def _mapped_way_id(self, id_: int) -> int:
+        return self._way_id_map.get(id_, id_)
+
+    def _mapped_relation_id(self, id_: int) -> int:
+        return self._relation_id_map.get(id_, id_)
+
+    def _build_id_remaps(self, xml_root: ET.Element) -> None:
+        """Remap way/relation ids that collide with other element kinds.
+
+        OSM keeps node, way, and relation ids in independent namespaces, while
+        :class:`Map` enforces a single one; official levelXdata lanelet2 maps
+        reuse numeric ids across kinds (e.g. exiD node 1500 vs way 1500).
+        Colliding ways and relations get ids from a free range, and every
+        member reference is resolved through the same tables, so maps without
+        collisions keep their original ids untouched.
+        """
+        node_ids = {int(node.attrib["id"]) for node in xml_root.findall("node")}
+        way_ids = [int(way.attrib["id"]) for way in xml_root.findall("way")]
+        relation_ids = [int(relation.attrib["id"]) for relation in xml_root.findall("relation")]
+
+        self._way_id_map = {}
+        self._relation_id_map = {}
+        used = set(node_ids)
+        next_id = max(used.union(way_ids, relation_ids), default=0) + 1
+
+        for way_id in way_ids:
+            if way_id in used:
+                self._way_id_map[way_id] = next_id
+                used.add(next_id)
+                next_id += 1
+            else:
+                used.add(way_id)
+
+        for relation_id in relation_ids:
+            if relation_id in used:
+                self._relation_id_map[relation_id] = next_id
+                used.add(next_id)
+                next_id += 1
+            else:
+                used.add(relation_id)
+
+        if self._way_id_map or self._relation_id_map:
+            logging.warning(
+                "%d way id(s) and %d relation id(s) collide with other element kinds; "
+                "remapped them to a free id range.",
+                len(self._way_id_map),
+                len(self._relation_id_map),
+            )
 
     def _append_point_list(self, point_list: list, new_points: list, component_id: int) -> None:
         """Append new points to an existing point list, handling direction alignment.
@@ -58,6 +109,67 @@ class OSMParser:
             raise SyntaxError(f"Points on the side of relation {component_id} is not continuous.")
 
         point_list += new_points[1:]
+
+    def _stitch_polylines(self, segments: list, component_id: int) -> list:
+        """Stitch member polylines into one chain regardless of member order.
+
+        Official lanelet2 exports do not guarantee that relation members are
+        listed head-to-tail, so segments are joined by matching endpoints in
+        any order and orientation. When no exact match remains, the chain is
+        bridged to the nearest remaining segment with a warning instead of
+        aborting the whole map.
+
+        Args:
+            segments (list): Lists of points, one per relation member.
+            component_id (int): The id of the relation, used for messages.
+
+        Returns:
+            list: The stitched point chain.
+        """
+        segments = [list(segment) for segment in segments if len(segment) > 0]
+        if not segments:
+            return []
+
+        chain = segments.pop(0)
+        while segments:
+            joined = False
+            for index, segment in enumerate(segments):
+                try:
+                    self._append_point_list(chain, list(segment), component_id)
+                except SyntaxError:
+                    continue
+                segments.pop(index)
+                joined = True
+                break
+            if joined:
+                continue
+
+            best_cost = None
+            best = None
+            for index, segment in enumerate(segments):
+                for chain_flip, chain_end in ((False, chain[-1]), (True, chain[0])):
+                    for segment_flip, segment_start in ((False, segment[0]), (True, segment[-1])):
+                        cost = (chain_end[0] - segment_start[0]) ** 2 + (
+                            chain_end[1] - segment_start[1]
+                        ) ** 2
+                        if best_cost is None or cost < best_cost:
+                            best_cost = cost
+                            best = (index, chain_flip, segment_flip)
+
+            index, chain_flip, segment_flip = best
+            segment = segments.pop(index)
+            if chain_flip:
+                chain.reverse()
+            if segment_flip:
+                segment.reverse()
+            logging.warning(
+                "Members of relation %s are not connected; bridging a gap of %.2f m.",
+                component_id,
+                best_cost**0.5,
+            )
+            chain += segment
+
+        return chain
 
     def _get_tags(self, xml_node: ET.Element) -> dict:
         """Parse OSM tags from an XML node into a dictionary.
@@ -151,18 +263,18 @@ class OSMParser:
         Returns:
             Area: The parsed area, or None if the outer boundary is empty or parsing fails.
         """
-        area_id = int(xml_node.attrib["id"])
+        area_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(inner=[], outer=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "outer":
-                line_ids["outer"].append(member_id)
+                line_ids["outer"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "inner":
-                line_ids["inner"].append(member_id)
+                line_ids["inner"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
         outer_point_list = []
         for line_id in line_ids["outer"]:
@@ -304,7 +416,7 @@ class OSMParser:
             Area | RoadLine: An Area if the way is closed or tagged as area,
                 otherwise a RoadLine.
         """
-        id_ = int(xml_node.attrib["id"])
+        id_ = self._mapped_way_id(int(xml_node.attrib["id"]))
         point_list = []
         point_ids = []
 
@@ -333,7 +445,7 @@ class OSMParser:
         Returns:
             Area | RoadLine | Regulatory: The parsed road element, or None if parsing fails.
         """
-        id_ = int(xml_node.attrib["id"])
+        id_ = self._mapped_relation_id(int(xml_node.attrib["id"]))
         tags = self._get_tags(xml_node)
         type_ = tags.pop("type")
         road_element = None
@@ -342,22 +454,16 @@ class OSMParser:
             road_element = self._parse_area(xml_node, map_)
 
         elif type_ == "route":
-            point_list = []
             line_ids = []
             for member in xml_node.findall("member"):
                 if member.attrib["type"] == "way":
-                    line_ids.append(int(member.attrib["ref"]))
-            for line_id in line_ids:
-                if len(point_list) == 0:
-                    if map_.roadlines.get(line_id):
-                        point_list = list(map_.roadlines[line_id].geometry.coords)
-                if map_.roadlines.get(line_id):
-                    new_points = list(map_.roadlines[line_id].geometry.coords)
-                    try:
-                        self._append_point_list(point_list, new_points, id_)
-                    except SyntaxError as err:
-                        logging.error(err)
-                        return None
+                    line_ids.append(self._mapped_way_id(int(member.attrib["ref"])))
+            segments = [
+                list(map_.roadlines[line_id].geometry.coords)
+                for line_id in line_ids
+                if map_.roadlines.get(line_id)
+            ]
+            point_list = self._stitch_polylines(segments, id_)
             road_element = RoadLine(id_, LineString(point_list), type_="route", custom_tags=tags)
 
         elif type_ == "restriction":
@@ -367,6 +473,10 @@ class OSMParser:
             vias = {}
             for member in xml_node.findall("member"):
                 member_id = int(member.attrib["ref"])
+                if member.attrib["type"] == "way":
+                    member_id = self._mapped_way_id(member_id)
+                elif member.attrib["type"] == "relation":
+                    member_id = self._mapped_relation_id(member_id)
                 if member.attrib["role"] == "from":
                     froms[member_id] = member.attrib["type"]
                 elif member.attrib["role"] == "to":
@@ -391,11 +501,17 @@ class OSMParser:
         Returns:
             RoadLine: A roadline with Lanelet2 tags.
         """
-        line_id = int(xml_node.attrib["id"])
+        line_id = self._mapped_way_id(int(xml_node.attrib["id"]))
         point_list = []
 
         for node in xml_node.findall("nd"):
-            point_list.append(map_.nodes[int(node.attrib["ref"])].location)
+            node_id = int(node.attrib["ref"])
+            if node_id not in map_.nodes:
+                logging.warning("Way %s references missing node %s; skipped it.", line_id, node_id)
+                continue
+            point_list.append(map_.nodes[node_id].location)
+        if len(point_list) < 2:
+            raise SyntaxError(f"Way {line_id} has fewer than 2 resolvable nodes.")
         linestring = LineString(point_list)
 
         tags = self._get_lanelet2_tags(xml_node)
@@ -412,25 +528,27 @@ class OSMParser:
         Returns:
             Lane: A lane with Lanelet2 tags and aligned left/right boundaries.
         """
-        lane_id = int(xml_node.attrib["id"])
+        lane_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(left=[], right=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "left":
-                line_ids["left"].append(member_id)
+                line_ids["left"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "right":
-                line_ids["right"].append(member_id)
+                line_ids["right"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
         point_list = {}
         for side in ["left", "right"]:
-            point_list[side] = list(map_.roadlines[line_ids[side][0]].geometry.coords)
-            for line_id in line_ids[side][1:]:
-                new_nodes = list(map_.roadlines[line_id].geometry.coords)
-                self._append_point_list(point_list[side], new_nodes, lane_id)
+            segments = [
+                list(map_.roadlines[line_id].geometry.coords) for line_id in line_ids[side]
+            ]
+            point_list[side] = self._stitch_polylines(segments, lane_id)
+            if len(point_list[side]) < 2:
+                raise SyntaxError(f"Lane {lane_id} has no usable {side} boundary.")
 
         left_side = LineString(point_list["left"])
         right_side = LineString(point_list["right"])
@@ -441,6 +559,19 @@ class OSMParser:
             left_side = LineString(point_list["left"])
         right_parallel = right_side.parallel_offset(0.1, "right")
         if right_side.hausdorff_distance(left_side) > right_parallel.hausdorff_distance(left_side):
+            point_list["right"].reverse()
+            right_side = LineString(point_list["right"])
+
+        # Robust orientation: the two sides of a lane must be parallel (both
+        # follow the lane direction; Lanelet2 convention: the left boundary
+        # defines the direction). The parallel_offset/hausdorff heuristic above
+        # is unreliable when the sides are antiparallel, so enforce consistency
+        # directly on the first/last-node direction vectors.
+        v_lx = point_list["left"][-1][0] - point_list["left"][0][0]
+        v_ly = point_list["left"][-1][1] - point_list["left"][0][1]
+        v_rx = point_list["right"][-1][0] - point_list["right"][0][0]
+        v_ry = point_list["right"][-1][1] - point_list["right"][0][1]
+        if v_lx * v_rx + v_ly * v_ry < 0.0:
             point_list["right"].reverse()
             right_side = LineString(point_list["right"])
 
@@ -468,23 +599,23 @@ class OSMParser:
         Returns:
             Area: An area with Lanelet2 tags.
         """
-        area_id = int(xml_node.attrib["id"])
+        area_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         line_ids = dict(inner=[], outer=[])
         regulatory_ids = []
 
         for member in xml_node.findall("member"):
             member_id = int(member.attrib["ref"])
             if member.attrib["role"] == "outer":
-                line_ids["outer"].append(member_id)
+                line_ids["outer"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "inner":
-                line_ids["inner"].append(member_id)
+                line_ids["inner"].append(self._mapped_way_id(member_id))
             elif member.attrib["role"] == "regulatory_element":
-                regulatory_ids.append(member_id)
+                regulatory_ids.append(self._mapped_relation_id(member_id))
 
-        outer_point_list = list(map_.roadlines[line_ids["outer"][0]].geometry.coords)
-        for line_id in line_ids["outer"][1:]:
-            new_points = list(map_.roadlines[line_id].geometry.coords)
-            self._append_point_list(outer_point_list, new_points, area_id)
+        outer_segments = [
+            list(map_.roadlines[line_id].geometry.coords) for line_id in line_ids["outer"]
+        ]
+        outer_point_list = self._stitch_polylines(outer_segments, area_id)
         if outer_point_list[0] != outer_point_list[-1]:
             logging.warning("The outer boundary of area %d is not closed.", area_id)
 
@@ -518,14 +649,16 @@ class OSMParser:
         Returns:
             Regulatory: A regulatory element with Lanelet2 tags.
         """
-        regulatory_id = int(xml_node.attrib["id"])
+        regulatory_id = self._mapped_relation_id(int(xml_node.attrib["id"]))
         relations = {}
         ways = {}
         for member in xml_node.findall("member"):
             if member.attrib["type"] == "relation":
-                relations[int(member.attrib["ref"])] = member.attrib["role"]
+                relations[self._mapped_relation_id(int(member.attrib["ref"]))] = member.attrib[
+                    "role"
+                ]
             elif member.attrib["type"] == "way":
-                ways[int(member.attrib["ref"])] = member.attrib["role"]
+                ways[self._mapped_way_id(int(member.attrib["ref"]))] = member.attrib["role"]
 
         regulatory_tags = self._get_lanelet2_tags(xml_node)
         if "speed_limit" in regulatory_tags:
@@ -549,6 +682,7 @@ class OSMParser:
             Map: A Tactics2D Map populated with all elements parsed from the OSM file.
         """
         xml_root = ET.parse(file_path).getroot()
+        self._build_id_remaps(xml_root)
 
         if configs is not None:
             project_rule = configs.get("project_rule", None)
@@ -596,33 +730,57 @@ class OSMParser:
             for xml_node in all_nodes:
                 map_.add_node(self._parse_nodes_no_proj(xml_node, lat0, lon0))
 
+        # A single malformed element (missing node reference, empty member
+        # list, degenerate geometry) degrades to a warning instead of
+        # aborting the whole map.
+        recoverable_errors = (KeyError, IndexError, ValueError, SyntaxError)
+
         if self.lanelet2:
             for xml_node in xml_root.findall("way"):
                 if xml_node.get("action") == "delete":
                     continue
-                map_.add_roadline(self._parse_roadline_lanelet2(xml_node, map_))
+                try:
+                    map_.add_roadline(self._parse_roadline_lanelet2(xml_node, map_))
+                except recoverable_errors as error:
+                    logging.warning(
+                        "Skipping way %s: %s", xml_node.attrib.get("id"), error
+                    )
 
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
                 for tag in xml_node.findall("tag"):
-                    if tag.attrib["v"] == "lanelet":
-                        map_.add_lane(self._parse_lane_lanelet2(xml_node, map_))
-                    elif tag.attrib["v"] in ["multipolygon", "area"]:
-                        map_.add_area(self._parse_area_lanelet2(xml_node, map_))
+                    try:
+                        if tag.attrib["v"] == "lanelet":
+                            map_.add_lane(self._parse_lane_lanelet2(xml_node, map_))
+                        elif tag.attrib["v"] in ["multipolygon", "area"]:
+                            map_.add_area(self._parse_area_lanelet2(xml_node, map_))
+                    except recoverable_errors as error:
+                        logging.warning(
+                            "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                        )
 
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
                 for tag in xml_node.findall("tag"):
                     if tag.attrib["v"] == "regulatory_element":
-                        map_.add_regulatory(self._parse_regulatory_lanelet2(xml_node))
+                        try:
+                            map_.add_regulatory(self._parse_regulatory_lanelet2(xml_node))
+                        except recoverable_errors as error:
+                            logging.warning(
+                                "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                            )
 
         else:
             for xml_node in xml_root.findall("way"):
                 if xml_node.get("action") == "delete":
                     continue
-                road_element = self._parse_way(xml_node, map_)
+                try:
+                    road_element = self._parse_way(xml_node, map_)
+                except recoverable_errors as error:
+                    logging.warning("Skipping way %s: %s", xml_node.attrib.get("id"), error)
+                    continue
 
                 if isinstance(road_element, RoadLine):
                     map_.add_roadline(road_element)
@@ -632,7 +790,13 @@ class OSMParser:
             for xml_node in xml_root.findall("relation"):
                 if xml_node.get("action") == "delete":
                     continue
-                road_element = self._parse_relation(xml_node, map_)
+                try:
+                    road_element = self._parse_relation(xml_node, map_)
+                except recoverable_errors as error:
+                    logging.warning(
+                        "Skipping relation %s: %s", xml_node.attrib.get("id"), error
+                    )
+                    continue
 
                 if isinstance(road_element, RoadLine):
                     map_.add_roadline(road_element)

--- a/tests/test_map_parser.py
+++ b/tests/test_map_parser.py
@@ -175,3 +175,136 @@ def test_net_xml_parser(runtime_dir, map_path, img_name):
     matplotlib_renderer.update(geometry_data)
     matplotlib_renderer.save_single_frame(save_to=runtime_dir / img_name)
     matplotlib_renderer.destroy()
+
+
+def _write_lanelet2_osm(path, nodes, ways, relations):
+    """Write a minimal lanelet2 OSM file from (id, ...) tuples."""
+    lines = ['<?xml version="1.0" encoding="UTF-8"?>', '<osm version="0.6">']
+    for node_id, lat, lon in nodes:
+        lines.append(f'  <node id="{node_id}" lat="{lat}" lon="{lon}"/>')
+    for way_id, node_ids in ways:
+        lines.append(f'  <way id="{way_id}">')
+        lines.extend(f'    <nd ref="{node_id}"/>' for node_id in node_ids)
+        lines.append('    <tag k="type" v="line_thin"/>')
+        lines.append("  </way>")
+    for relation_id, members, tags in relations:
+        lines.append(f'  <relation id="{relation_id}">')
+        for member_type, ref, role in members:
+            lines.append(f'    <member type="{member_type}" ref="{ref}" role="{role}"/>')
+        for key, value in tags:
+            lines.append(f'    <tag k="{key}" v="{value}"/>')
+        lines.append("  </relation>")
+    lines.append("</osm>")
+    path.write_text("\n".join(lines))
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_remaps_colliding_ids(tmp_path):
+    """Node/way/relation ids live in independent OSM namespaces (issue #291)."""
+    osm = tmp_path / "collide.osm"
+    # Node 1, way 1, and relation 1 coexist; ways 2/3 also collide with nodes.
+    _write_lanelet2_osm(
+        osm,
+        nodes=[(1, 50.0, 6.0), (2, 50.0001, 6.0), (3, 50.0, 6.0002), (4, 50.0001, 6.0002)],
+        ways=[(1, [1, 3]), (2, [2, 4])],
+        relations=[
+            (
+                1,
+                [("way", 1, "left"), ("way", 2, "right"), ("relation", 5, "regulatory_element")],
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                5,
+                [("relation", 1, "refers")],
+                [("type", "regulatory_element"), ("subtype", "speed_limit")],
+            ),
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    assert len(map_.roadlines) == 2
+    assert len(map_.lanes) == 1
+    assert len(map_.regulations) == 1
+    lane = next(iter(map_.lanes.values()))
+    # Member references follow the remapped way ids.
+    assert all(line_id in map_.roadlines for side in ("left", "right") for line_id in lane.line_ids[side])
+    # The regulatory element still points at the (remapped) lane relation.
+    regulatory = next(iter(map_.regulations.values()))
+    assert set(regulatory.relations) == {lane.id_}
+    assert lane.regulatory_ids == {regulatory.id_}
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_stitches_out_of_order_members(tmp_path):
+    """Relation members are not guaranteed head-to-tail; stitch by endpoints."""
+    osm = tmp_path / "unordered.osm"
+    # Left side is split into two ways listed in reverse order: 20 then 10.
+    _write_lanelet2_osm(
+        osm,
+        nodes=[
+            (101, 50.0, 6.0),
+            (102, 50.0, 6.0001),
+            (103, 50.0, 6.0002),
+            (104, 50.0001, 6.0),
+            (105, 50.0001, 6.0002),
+        ],
+        ways=[(10, [101, 102]), (20, [102, 103]), (30, [104, 105])],
+        relations=[
+            (
+                40,
+                [("way", 20, "left"), ("way", 10, "left"), ("way", 30, "right")],
+                [("type", "lanelet"), ("subtype", "road")],
+            )
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    assert len(map_.lanes) == 1
+    lane = next(iter(map_.lanes.values()))
+    assert len(lane.left_side.coords) == 3  # both left segments joined
+
+
+@pytest.mark.map_parser
+def test_lanelet2_parser_skips_broken_elements(tmp_path):
+    """Missing node references degrade to skipped elements, not a failed map."""
+    osm = tmp_path / "broken.osm"
+    _write_lanelet2_osm(
+        osm,
+        nodes=[
+            (101, 50.0, 6.0),
+            (102, 50.0, 6.0002),
+            (103, 50.0001, 6.0),
+            (104, 50.0001, 6.0002),
+            (105, 50.0002, 6.0),
+        ],
+        ways=[
+            (10, [101, 102]),
+            (20, [103, 104]),
+            (30, [105, 999999]),  # dangling node reference
+        ],
+        relations=[
+            (
+                40,
+                [("way", 10, "left"), ("way", 20, "right")],
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                41,
+                [("way", 10, "left"), ("way", 30, "right")],  # references the broken way
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+            (
+                42,
+                [],  # no members at all
+                [("type", "lanelet"), ("subtype", "road")],
+            ),
+        ],
+    )
+
+    map_ = OSMParser(lanelet2=True).parse(str(osm))
+
+    # Way 30 degenerates to a single point and is skipped; lane 40 survives.
+    assert 30 not in map_.roadlines
+    assert set(map_.lanes) == {40}


### PR DESCRIPTION
…geometry and element id binding in osm parser

## Summary

Describe what this PR changes and why.
请简要说明这个 PR 修改了什么，以及原因。

## Motivation and Context

Why is this change needed? What user/problem does it address?
为什么需要这个改动？它解决了什么问题？

## Changes (Mandatory)

- Improve parsing efficiency of womd and nuplan
- Fix geometry auto-complete error in osm parser
- Fix id assignment in map processing

## Testing (Mandatory)

List what you ran locally and the result.
请填写你在本地执行的检查项和结果。

- [-] `pre-commit run --all-files` passed
- [-] `pytest` passed
- [-] Documentation style/format checked (Google-style docstrings and docs formatting)

Result summary (ignore if all checks passed):

## Reviewer Checklist (Author)

- [-] PR title follows project style (clear prefix + concise summary, e.g. `Fix: ...`, `Feat: ...`, `Docs: ...`)
- [-] PR title follows gitmoji recommendation for its change type
- [-] Appropriate labels have been applied
- [-] Reviewer(s) have been assigned
- [-] Code documentation/docstrings in this PR are written in English
- [-] This PR is ready for review

## Title Recommendation (Remove this section after updating the title)

Use a concise title with a gitmoji + prefix style.
建议使用 gitmoji + 前缀 + 简短摘要的标题风格。

Examples:

- `🐛 Bug: fix lane boundary parsing in OSM loader`
- `✨ Feat: add trajectory smoothing option`
- `📝 Docs: clarify installation steps for Linux`
- `♻️ Refactor: simplify map element validation`
- `🧪 Test: add regression case for rrt planner`
- `🔧 CI: speed up workflow cache restore`
- `⬆️ Deps: bump shapely to 2.1.0`

Suggested gitmoji mapping:

- `🐛` bug fix
- `✨` enhancement/feature
- `♻️` refactor
- `🎨` format/style only
- `📝` documentation
- `🧪` pytest/tests
- `🔧` actions/CI
- `⬆️` dependencies

## Labels to Apply (Remove this section after applying labels)

Select the labels that match this PR.
请选择与本 PR 对应的标签。

### Type labels

- [ ] `bug`
- [ ] `enhancement`
- [ ] `refactor`
- [ ] `format`
- [ ] `documentation`
- [ ] `pytest`
- [ ] `actions`
- [ ] `dependencies`
- [ ] `duplicate`
- [ ] `invalid`
- [ ] `question`
- [ ] `needs info`
- [ ] `help wanted`
- [ ] `safe to test`
- [ ] `wontfix`

### Area labels

- [ ] `area: python`
- [ ] `area: frontend`
- [ ] `area: c++`
