### PR TITLE
✨ Feat: speed up simulation and raise single-track physics fidelity

### DIFF
--- a/tactics2d/behavior/limsim/scene.py
+++ b/tactics2d/behavior/limsim/scene.py
@@ -10,6 +10,7 @@ from shapely.geometry import LineString, Point
 
 from tactics2d.geometry import normalize_angle
 from tactics2d.map.element import Map
+from tactics2d.map.element.map import HAS_STRTREE
 from tactics2d.participant.trajectory import State
 from tactics2d.routing.utils import find_nearest_lane, get_lane_centerline
 
@@ -99,7 +100,9 @@ class SceneBuilder:
             distance = lane.geometry.distance(point) if projection is None else projection.distance
             if distance > self.config.lane_match_radius:
                 continue
-            lane_heading = self._lane_heading_at(lane, projection.s if projection is not None else None)
+            lane_heading = self._lane_heading_at(
+                lane, projection.s if projection is not None else None
+            )
             heading_error = 0.0
             if lane_heading is not None:
                 heading_error = abs(normalize_angle(state.heading - lane_heading))
@@ -114,12 +117,18 @@ class SceneBuilder:
         lane = map_.lanes.get(lane_id)
         point = Point(point_xy)
         lane_ids = set()
-        for candidate_id, candidate_lane in map_.lanes.items():
-            if candidate_lane.geometry is None:
+        # Broad-phase: use the map spatial index when available, else full scan.
+        if HAS_STRTREE and map_._element_geometries:
+            candidate_ids = map_.query_point(point_xy, buffer=self.config.lane_match_radius)
+        else:
+            candidate_ids = list(map_.lanes.keys())
+        for candidate_id in candidate_ids:
+            candidate_lane = map_.lanes.get(candidate_id)
+            if candidate_lane is None or candidate_lane.geometry is None:
                 continue
-            centerline = get_lane_centerline(candidate_lane)
+            centerline = candidate_lane.centerline()
             if centerline is not None:
-                distance = LineString(centerline).distance(point)
+                distance = centerline.distance(point)
             else:
                 distance = candidate_lane.geometry.distance(point)
             if distance <= self.config.lane_match_radius:

--- a/tactics2d/dataset_parser/parse_driveinsightd.py
+++ b/tactics2d/dataset_parser/parse_driveinsightd.py
@@ -1,9 +1,7 @@
-#! python3
 # Copyright (C) 2026, Tactics2D Authors. Released under the GNU GPLv3.
-# @File: parse_driveinsightd.py
-# @Description: This file implements a parser of the DriveInsight Dataset.
-# @Author: Zexi Chen
-# @Version: 1.0.0
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""DriveInsightD parser implementation."""
 
 import logging
 import xml.etree.ElementTree as ET

--- a/tactics2d/display/renderers/pygame/renderer.py
+++ b/tactics2d/display/renderers/pygame/renderer.py
@@ -229,7 +229,30 @@ class PygameRenderer:
         point_size = max(1, int(point_cloud.get("point_size", 1)))
         a, b, d, e, x_off, y_off = transform
 
-        for pt in point_cloud.get("points", []):
-            px = a * pt[0] + b * pt[1] + x_off
-            py = d * pt[0] + e * pt[1] + y_off
-            pygame.draw.circle(self._surface, colour, (px, py), point_size)
+        points = point_cloud.get("points", [])
+        if not points:
+            return
+        arr = np.asarray(points, dtype=float)
+        px = (arr[:, 0] * a + arr[:, 1] * b + x_off).astype(int)
+        py = (arr[:, 0] * d + arr[:, 1] * e + y_off).astype(int)
+
+        # Clip to the surface bounds before drawing.
+        height, width = self._surface.get_height(), self._surface.get_width()
+        in_bounds = (px >= 0) & (px < width) & (py >= 0) & (py < height)
+        px, py = px[in_bounds], py[in_bounds]
+        if len(px) == 0:
+            return
+
+        if point_size <= 1:
+            # Fast path: write 1 px dots directly through the surface pixel view
+            # (one vectorized assignment instead of one draw call per point).
+            try:
+                pixels = pygame.surfarray.pixels3d(self._surface)
+                pixels[px, py] = (colour.r, colour.g, colour.b)
+                del pixels  # release the surface lock
+            except (ValueError, pygame.error):
+                for x, y in zip(px.tolist(), py.tolist()):
+                    pygame.draw.circle(self._surface, colour, (x, y), point_size)
+        else:
+            for x, y in zip(px.tolist(), py.tolist()):
+                pygame.draw.circle(self._surface, colour, (x, y), point_size)

--- a/tactics2d/display/renderers/web/preview.py
+++ b/tactics2d/display/renderers/web/preview.py
@@ -462,11 +462,7 @@ def discover_interaction_datasets() -> list[dict[str, Any]]:
                             files.append(f"{scenario_dir.name}/{int(match.group(1))}")
                 if files:
                     return [
-                        {
-                            "dataset": INTERACTION_DATASET,
-                            "folder": str(tracks_root),
-                            "files": files,
-                        }
+                        {"dataset": INTERACTION_DATASET, "folder": str(tracks_root), "files": files}
                     ]
     return []
 
@@ -832,6 +828,13 @@ def _shift_map_origin(map_: Any) -> tuple[float, float]:
         boundary[2] - origin_y,
         boundary[3] - origin_y,
     )
+
+    # Re-sync the spatial index so broad-phase queries (e.g. the BEV camera
+    # prefilter) see the translated geometry, not the original UTM coordinates.
+    for elements in (map_.roadlines, map_.lanes, map_.areas, map_.junctions):
+        for element in elements.values():
+            map_._add_element_to_spatial_index(element.id_, element)
+
     return origin_x, origin_y
 
 

--- a/tactics2d/display/sensor/camera.py
+++ b/tactics2d/display/sensor/camera.py
@@ -10,6 +10,7 @@ import numpy as np
 from shapely.geometry import Point, Polygon
 
 from tactics2d.map.element import Area, Junction, Lane, Map, RoadLine
+from tactics2d.map.element.map import HAS_STRTREE
 from tactics2d.participant.element import Cyclist, Obstacle, Other, Pedestrian, Vehicle
 
 from .sensor_base import SensorBase
@@ -141,8 +142,18 @@ class BEVCamera(SensorBase):
         road_element_list = []
         white = "white"
 
+        # Broad-phase: when a position is set and the map has a spatial index,
+        # restrict the per-element distance filter to candidates near the camera.
+        candidate_ids = None
+        if self._position is not None and HAS_STRTREE and self._map._element_geometries:
+            candidate_ids = set(
+                self._map.query_point(self._position, buffer=self.max_perception_distance * 1.5)
+            )
+
         for area in self._map.areas.values():
             if area.geometry is None:
+                continue
+            if candidate_ids is not None and area.id_ not in candidate_ids:
                 continue
             if not self._in_perception_range(area.geometry):
                 continue
@@ -180,6 +191,8 @@ class BEVCamera(SensorBase):
         for lane in self._map.lanes.values():
             if lane.geometry is None:
                 continue
+            if candidate_ids is not None and lane.id_ not in candidate_ids:
+                continue
             if not self._in_perception_range(lane.geometry):
                 continue
 
@@ -208,6 +221,8 @@ class BEVCamera(SensorBase):
 
         for roadline in self._map.roadlines.values():
             if roadline.geometry is None:
+                continue
+            if candidate_ids is not None and roadline.id_ not in candidate_ids:
                 continue
             if roadline.type_ == "virtual" or not self._in_perception_range(roadline.geometry):
                 continue

--- a/tactics2d/map/element/lane.py
+++ b/tactics2d/map/element/lane.py
@@ -81,6 +81,7 @@ class Lane:
         "successors",
         "left_neighbors",
         "right_neighbors",
+        "_centerline",
     )
 
     _speed_units = ["km/h", "mi/h", "m/s", "mph"]
@@ -134,6 +135,7 @@ class Lane:
         self.inferred_participants = inferred_participants
         self.speed_limit_mandatory = speed_limit_mandatory
         self.custom_tags = custom_tags
+        self._centerline = None
 
         if None not in [left_side, right_side]:
             self.geometry = LinearRing(
@@ -179,12 +181,22 @@ class Lane:
         return list(self.geometry.coords)
 
     def centerline(self) -> Optional[LineString]:
-        """Return the lane centerline if it can be obtained."""
+        """Return the lane centerline if it can be obtained.
+
+        The result is cached on first access. In the parsers and generators the
+        side boundaries are set once at construction, so the cache is safe;
+        code that reassigns ``left_side`` / ``right_side`` / ``custom_tags``
+        afterwards must clear ``lane._centerline``.
+        """
+
+        if self._centerline is not None:
+            return self._centerline
 
         if self.custom_tags is not None and "centerline" in self.custom_tags:
             centerline = np.asarray(self.custom_tags["centerline"], dtype=float)
             if centerline.ndim == 2 and centerline.shape[1] == 2 and len(centerline) >= 2:
-                return LineString(centerline)
+                self._centerline = LineString(centerline)
+                return self._centerline
 
         if self.left_side is None or self.right_side is None:
             return None
@@ -202,7 +214,8 @@ class Lane:
             points.append(
                 (0.5 * (left_point.x + right_point.x), 0.5 * (left_point.y + right_point.y))
             )
-        return LineString(points)
+        self._centerline = LineString(points)
+        return self._centerline
 
     def get_width(self, samples: int = 5, default: Optional[float] = None) -> Optional[float]:
         """Estimate lane width by sampling distances between left and right boundaries."""

--- a/tactics2d/map/parser/parse_xodr.py
+++ b/tactics2d/map/parser/parse_xodr.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2026, Tactics2D Authors. Released under the GNU GPLv3.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""OpenDRIVE parser implementation."""
+
 from __future__ import annotations
 
 import logging
@@ -109,6 +111,33 @@ def _eval_cubic_poly(records: list, s: float, s_key: str = "s") -> float:
             break
     ds = s - active[s_key]
     return active["a"] + active["b"] * ds + active["c"] * ds**2 + active["d"] * ds**3
+
+
+def _eval_cubic_poly_vec(records: list, s_arr, s_key: str = "s") -> np.ndarray:
+    """Vectorized ``_eval_cubic_poly`` over an array of arc-lengths.
+
+    The piecewise segments must be sorted ascending by ``s_key`` (as produced
+    by the XODR parsers). Returns an array of evaluated polynomial values, one
+    per element of ``s_arr``.
+
+    Args:
+        records (list): List of dicts with keys s_key, a, b, c, d.
+        s_arr (Sequence[float]): Arc-length values at which to evaluate.
+        s_key (str): Key for the segment start value. Defaults to "s".
+
+    Returns:
+        np.ndarray: Evaluated polynomial values.
+    """
+    s_arr = np.asarray(s_arr, dtype=float)
+    if not records or len(s_arr) == 0:
+        return np.zeros(len(s_arr), dtype=float)
+    s_start = np.array([rec[s_key] for rec in records], dtype=float)
+    coeff = np.array([[rec["a"], rec["b"], rec["c"], rec["d"]] for rec in records], dtype=float)
+    idx = np.searchsorted(s_start, s_arr, side="right") - 1
+    idx = np.clip(idx, 0, len(records) - 1)  # match scalar fallback to records[0]
+    ds = s_arr - s_start[idx]
+    a, b, c, d = coeff[idx].T
+    return a + b * ds + c * ds**2 + d * ds**3
 
 
 def _build_offset_polyline(
@@ -273,7 +302,8 @@ class XODRParser:
 
         n = max(2, int(L / 0.1) + 1)
         s_arr = np.linspace(0.0, L, n)
-        pts = [(x0 + s * np.cos(hdg), y0 + s * np.sin(hdg)) for s in s_arr]
+        cos_hdg, sin_hdg = np.cos(hdg), np.sin(hdg)
+        pts = np.column_stack((x0 + s_arr * cos_hdg, y0 + s_arr * sin_hdg)).tolist()
         kappas = [0.0] * len(pts)
         return pts, kappas
 
@@ -644,9 +674,7 @@ class XODRParser:
         width_records = self._parse_width_records(lane_node)
 
         ls_s0 = float(ref_s[0])
-        width_at_s = np.array(
-            [_eval_cubic_poly(width_records, float(s) - ls_s0, s_key="sOffset") for s in ref_s]
-        )
+        width_at_s = _eval_cubic_poly_vec(width_records, ref_s - ls_s0, s_key="sOffset")
 
         outer_t = inner_t + sign * width_at_s
 
@@ -828,9 +856,7 @@ class XODRParser:
             key=lambda r: r["s"],
         )
 
-        lane_offset_t = np.array(
-            [_eval_cubic_poly(lane_offset_records, float(s), s_key="s") for s in s_arr]
-        )
+        lane_offset_t = _eval_cubic_poly_vec(lane_offset_records, s_arr, s_key="s")
 
         center_pts = pts_arr + lane_offset_t[:, np.newaxis] * ref_normals
 

--- a/tactics2d/participant/element/vehicle.py
+++ b/tactics2d/participant/element/vehicle.py
@@ -108,6 +108,8 @@ class Vehicle(ParticipantBase):
 
         super().__init__(id_, type_, trajectory, **kwargs)
 
+        self._pose_cache = None  # (frame, pose) cached per frame; see get_pose
+
         self.max_steer = np.round(np.pi / 6, 3) if self.max_steer is None else self.max_steer
         self.max_speed = 55.56 if self.max_speed is None else self.max_speed
         self.max_accel = 3.0 if self.max_accel is None else self.max_accel
@@ -219,6 +221,17 @@ class Vehicle(ParticipantBase):
                     [-0.5 * self.length, -0.5 * self.width],
                 ]
             )
+        self._pose_cache = None
+
+    def reset(self, state: State = None, keep_history: bool = False):
+        """Reset the vehicle and invalidate its cached pose.
+
+        Args:
+            state (State, optional): The initial state of the object.
+            keep_history (bool, optional): Whether to keep the record of history trajectory.
+        """
+        super().reset(state, keep_history)
+        self._pose_cache = None
 
     def add_state(self, state: State):
         """This function adds a state to the vehicle.
@@ -235,6 +248,7 @@ class Vehicle(ParticipantBase):
                 "Invalid state checked by the physics model %s."
                 % (self.physics_model.__class__.__name__)
             )
+        self._pose_cache = None
 
     def bind_trajectory(self, trajectory: Trajectory):
         """This function binds a trajectory to the vehicle.
@@ -259,9 +273,15 @@ class Vehicle(ParticipantBase):
         else:
             self.trajectory = trajectory
             logging.debug(f"Vehicle {self.id_} is bound to a trajectory without verification.")
+        self._pose_cache = None
 
     def get_pose(self, frame: int = None) -> LinearRing:
         """This function gets the pose of the vehicle at the requested frame.
+
+        The pose is cached per frame and invalidated whenever the trajectory is
+        mutated (``add_state`` / ``bind_trajectory`` / ``reset``) or the bounding
+        box is rebuilt (``load_from_template``), so repeated queries within one
+        simulation step reuse the same Shapely ``affine_transform``.
 
         Args:
             frame (int, optional): The frame to get the vehicle's pose.
@@ -269,6 +289,9 @@ class Vehicle(ParticipantBase):
         Returns:
             pose (LinearRing): The vehicle's bounding box which is rotated and moved based on the current state.
         """
+        if self._pose_cache is not None and self._pose_cache[0] == frame:
+            return self._pose_cache[1]
+
         state = self.trajectory.get_state(frame)
         transform_matrix = [
             np.cos(state.heading),
@@ -278,7 +301,9 @@ class Vehicle(ParticipantBase):
             state.location[0],
             state.location[1],
         ]
-        return affine_transform(self._bbox, transform_matrix)
+        pose = affine_transform(self._bbox, transform_matrix)
+        self._pose_cache = (frame, pose)
+        return pose
 
     def get_trace(self, frame_range: Tuple[int, int] = None) -> LinearRing:
         """This function gets the trace of the vehicle within the requested frame range.

--- a/tactics2d/participant/element/vehicle.py
+++ b/tactics2d/participant/element/vehicle.py
@@ -12,7 +12,7 @@ from shapely.affinity import affine_transform
 from shapely.geometry import LinearRing, LineString
 
 from tactics2d.participant.trajectory import State, Trajectory
-from tactics2d.physics import SingleTrackKinematics
+from tactics2d.physics import SingleTrackDrift, SingleTrackDynamics, SingleTrackKinematics
 
 from .participant_base import ParticipantBase
 from .participant_template import EPA_MAPPING, EURO_SEGMENT_MAPPING, NCAP_MAPPING, VEHICLE_TEMPLATE
@@ -147,25 +147,116 @@ class Vehicle(ParticipantBase):
     def geometry(self) -> LinearRing:
         return self._bbox
 
+    def build_physics_model(
+        self,
+        model_class=SingleTrackKinematics,
+        *,
+        mu: float = None,
+        I_z: float = None,
+        cf: float = None,
+        cr: float = None,
+        radius: float = None,
+        mass_height: float = None,
+        interval: int = 100,
+        delta_t: int = None,
+        **kwargs,
+    ):
+        """Build a physics model from this vehicle's template parameters.
+
+        The real geometry and mass of the participant (``lf``/``lr`` from the overhangs or
+        half length, ``mass`` from the kerb weight, ``mass_height`` from half the height) and
+        its steer/speed/accel ranges are filled in automatically, so only vehicle/road
+        specific knobs need to be passed explicitly. This method does not assign
+        ``self.physics_model``; callers that want verification can assign the return value.
+
+        Note that the vehicle template carries geometry, mass and performance only - it has no
+        real ``I_z`` (not published for production cars), so dynamics/drift keep the
+        CommonRoad reference-vehicle defaults (Ford Escort) unless overridden. ``mu`` is a
+        tire-road property (not a vehicle property): use the same value for every model that
+        shares a road surface.
+
+        Args:
+            model_class (type, optional): A physics model class, one of
+                ``SingleTrackKinematics`` (default), ``SingleTrackDynamics`` or
+                ``SingleTrackDrift``.
+            mu (float, optional): Tire-road friction coefficient. Applied to the kinematics
+                (grip-limit cap) and the dynamics (friction coefficient) models. ``SingleTrackDrift``
+                derives friction from its Pacejka tire, so ``mu`` is ignored for it.
+            I_z (float, optional): Yaw moment of inertia (kg/m^2). None keeps the class default.
+            cf (float, optional): Front cornering stiffness (1/rad). Dynamics only; None keeps the class default.
+            cr (float, optional): Rear cornering stiffness (1/rad). Dynamics only; None keeps the class default.
+            radius (float, optional): Effective wheel radius (m). Drift only; None keeps the class default.
+            mass_height (float, optional): Center-of-mass height (m). Defaults to half the vehicle height.
+            interval (int, optional): Physics step interval (ms). Defaults to 100.
+            delta_t (int, optional): Internal sub-step (ms). None uses the class default.
+
+        Keyword Args:
+            **kwargs: Extra keyword arguments passed to the model constructor, e.g.
+                ``friction_ellipse=True`` for ``SingleTrackDynamics``.
+
+        Returns:
+            physics_model (PhysicsModelBase): The constructed physics model.
+
+        Raises:
+            ValueError: If the model requires ``mass_height`` but the vehicle has no height
+                and none was provided.
+        """
+        if self.length is None:
+            raise ValueError("The vehicle has no length; cannot derive the wheel base.")
+        if None not in [self.front_overhang, self.rear_overhang]:
+            lf = self.length / 2 - self.front_overhang
+            lr = self.length / 2 - self.rear_overhang
+        else:
+            lf = self.length / 2
+            lr = self.length / 2
+
+        params = dict(
+            lf=lf,
+            lr=lr,
+            steer_range=self.steer_range,
+            speed_range=self.speed_range,
+            accel_range=self.accel_range,
+            interval=interval,
+            delta_t=delta_t,
+            **kwargs,
+        )
+
+        needs_mass = issubclass(model_class, (SingleTrackDynamics, SingleTrackDrift))
+        if needs_mass:
+            params["mass"] = self.kerb_weight
+            if mass_height is None:
+                if self.height is None:
+                    raise ValueError(
+                        "The model needs mass_height but the vehicle has no height; pass mass_height explicitly."
+                    )
+                mass_height = self.height / 2
+            params["mass_height"] = mass_height
+
+        if issubclass(model_class, SingleTrackDynamics):
+            if mu is not None:
+                params["mu"] = mu
+            if I_z is not None:
+                params["I_z"] = I_z
+            if cf is not None:
+                params["cf"] = cf
+            if cr is not None:
+                params["cr"] = cr
+        elif issubclass(model_class, SingleTrackDrift):
+            if I_z is not None:
+                params["I_z"] = I_z
+            if radius is not None:
+                params["radius"] = radius
+        elif mu is not None:
+            # SingleTrackKinematics: grip-limit cap is opt-in via mu.
+            params["mu"] = mu
+
+        return model_class(**params)
+
     def _auto_construct_physics_model(self):
         # Auto-construct the physics model for front-wheel-drive (FWD) vehicles.
         if self.driven_mode == "FWD":
-            if None not in [self.front_overhang, self.rear_overhang]:
-                self.physics_model = SingleTrackKinematics(
-                    lf=self.length / 2 - self.front_overhang,
-                    lr=self.length / 2 - self.rear_overhang,
-                    steer_range=self.steer_range,
-                    speed_range=self.speed_range,
-                    accel_range=self.accel_range,
-                )
-            elif self.length is not None:
-                self.physics_model = SingleTrackKinematics(
-                    lf=self.length / 2,
-                    lr=self.length / 2,
-                    steer_range=self.steer_range,
-                    speed_range=self.speed_range,
-                    accel_range=self.accel_range,
-                )
+            if self.length is not None:
+                self.physics_model = self.build_physics_model(SingleTrackKinematics)
             else:
                 self.verify = False
                 logging.info(

--- a/tactics2d/participant/trajectory/state.py
+++ b/tactics2d/participant/trajectory/state.py
@@ -74,22 +74,39 @@ class State:
         Raises:
             ValueError: If the type of the input value cannot be converted to the expected type, the function will raise a ValueError.
         """
-        setattr(self, "frame", frame)
-        setattr(self, "x", x)
-        setattr(self, "y", y)
-        setattr(self, "heading", heading)
-        setattr(self, "vx", vx)
-        setattr(self, "vy", vy)
-        setattr(self, "_speed", speed)
-        setattr(self, "ax", ax)
-        setattr(self, "ay", ay)
-        setattr(self, "_accel", accel)
+        # Assign fields directly, bypassing the __setattr__ validation machinery
+        # (which guards post-construction attribute sets). Type coercion is done
+        # here once: None is preserved, values already of the declared type are
+        # kept as-is, everything else is converted.
+        annotations = self.__annotations__
+        values = (
+            ("frame", frame),
+            ("x", x),
+            ("y", y),
+            ("heading", heading),
+            ("vx", vx),
+            ("vy", vy),
+            ("_speed", speed),
+            ("ax", ax),
+            ("ay", ay),
+            ("_accel", accel),
+        )
+        for name, value in values:
+            expected = annotations[name]
+            if value is not None and not isinstance(value, expected):
+                try:
+                    value = expected(value)
+                except Exception:
+                    raise ValueError(
+                        f"Failed to convert {value} to the expected type of {name}: ({expected})."
+                    )
+            object.__setattr__(self, name, value)
 
         # Initialize cache variables
-        super().__setattr__("_cached_speed", None)
-        super().__setattr__("_cached_velocity", None)
-        super().__setattr__("_cached_accel", None)
-        super().__setattr__("_cached_acceleration", None)
+        object.__setattr__(self, "_cached_speed", None)
+        object.__setattr__(self, "_cached_velocity", None)
+        object.__setattr__(self, "_cached_accel", None)
+        object.__setattr__(self, "_cached_acceleration", None)
 
     def _invalidate_cache(self, attr_name: str) -> None:
         """Invalidate cache based on which attribute changed."""

--- a/tactics2d/participant/trajectory/state.py
+++ b/tactics2d/participant/trajectory/state.py
@@ -26,6 +26,8 @@ class State:
         ax (float): The acceleration in the x-axis. The unit is meter per second squared (m/s$^2$).
         ay (float): The acceleration in the y-axis. The unit is meter per second squared (m/s$^2$).
         accel (float): The scalar acceleration value. The unit is meter per second squared (m/s$^2$). This attribute can be set while initialization or by `set_accel`. If it is not set while ax and ay are available, accel will be obtained by sqrt(ax$^2$+ay$^2$). Otherwise, the accel will be None.
+        yaw_rate (float, optional): The yaw rate (angular velocity of the heading). The unit is radian per second (rad/s). Defaults to None. Used by the single-track dynamics/drift models to carry the yaw rate between integration steps; other participants leave it None.
+        slip_angle (float, optional): The slip angle at the center of the vehicle. The unit is radian. Defaults to None. Used by the single-track dynamics/drift models to carry the slip angle between integration steps; other participants leave it None.
         location (Tuple[float, float]): The location. The unit is meter. This attribute is **read-only**.
         velocity (Tuple[float, float]): The velocity vector (vx, vy). The unit is meter per second (m/s). If vx and vy are not available but speed and heading are available, the velocity will be obtained by (speed * cos(heading), speed * sin(heading)). Otherwise, the velocity will be None. This attribute is **read-only**.
         acceleration (Tuple[float, float]): The acceleration vector (ax, ay). The unit is meter per second squared (m/s$^2$). If ax and ay are not available, the acceleration will be None. This attribute is **read-only**.
@@ -42,6 +44,8 @@ class State:
         "ax": float,
         "ay": float,
         "_accel": float,
+        "yaw_rate": float,
+        "slip_angle": float,
     }
 
     def __init__(
@@ -56,6 +60,8 @@ class State:
         ax: float = None,
         ay: float = None,
         accel: float = None,
+        yaw_rate: float = None,
+        slip_angle: float = None,
     ):
         """Initialize the state of a traffic participant.
 
@@ -70,6 +76,8 @@ class State:
             ax (float, optional): The acceleration in the x-axis. The unit is meter per second squared (m/s$^2$).
             ay (float, optional): The acceleration in the y-axis. The unit is meter per second squared (m/s$^2$).
             accel (float, optional): The scalar acceleration value. The unit is meter per second squared (m/s$^2$).
+            yaw_rate (float, optional): The yaw rate. The unit is radian per second (rad/s).
+            slip_angle (float, optional): The slip angle at the vehicle center. The unit is radian.
 
         Raises:
             ValueError: If the type of the input value cannot be converted to the expected type, the function will raise a ValueError.
@@ -90,6 +98,8 @@ class State:
             ("ax", ax),
             ("ay", ay),
             ("_accel", accel),
+            ("yaw_rate", yaw_rate),
+            ("slip_angle", slip_angle),
         )
         for name, value in values:
             expected = annotations[name]

--- a/tactics2d/physics/physics_model_base.py
+++ b/tactics2d/physics/physics_model_base.py
@@ -4,7 +4,10 @@
 """Physics model base implementation."""
 
 
+import math
 from abc import ABC, abstractmethod
+
+import numpy as np
 
 from tactics2d.participant.trajectory import State, Trajectory
 
@@ -68,5 +71,83 @@ class PhysicsModelBase(ABC):
             interval = interval if trajectory.stable_freq else state.frame - last_state.frame
             if self.verify_state(state, last_state, interval) is False:
                 return False
+
+        return True
+
+    def _verify_kinematic_state(
+        self, state: State, last_state: State, interval: int = None, *, grip: float = None
+    ) -> bool:
+        """Shared "very rough" reachability check for the single-track models.
+
+        Checks that a proposed state is consistent with a one-step transition of a bicycle
+        model given the steer/speed/accel ranges:
+
+        - the heading advance is within what the extreme steering angles can produce
+          (optionally grip-limited by ``grip`` = ``mu * g`` in m/s^2, as used by the kinematics
+          grip cap);
+        - the speed is reachable within one step of the acceleration range (speed-clamped);
+        - the travel distance is plausible. Steering only changes the direction, not the arc
+          length, and the Euclidean displacement (chord) never exceeds the straight-line travel
+          distance, so the position is bounded by the max straight travel of the step
+          instead of an axis-aligned box that wrongly paired the max speed with the extreme
+          steering angle (which rejected legitimate accelerating near-straight steps).
+
+        Args:
+            state (State): The candidate state to check.
+            last_state (State): The previous state.
+            interval (int, optional): Time between the two states in ms; derived from the
+                frame difference when None.
+            grip (float, optional): Grip-limit ``mu * g`` (m/s^2). When set and the vehicle
+                moves forward, the extreme-steer heading advance is capped like the model's
+                ``_step`` does.
+
+        Returns:
+            True if the transition looks reachable, False otherwise.
+        """
+        interval = state.frame - last_state.frame if interval is None else interval
+        # Handle zero interval case
+        if interval == 0:
+            return True  # No time elapsed, state should be valid
+        dt = float(interval) / 1000
+        last_speed = last_state.speed
+
+        if None in [self.steer_range, self.speed_range, self.accel_range]:
+            return True
+
+        steer_range = np.array(self.steer_range)
+        beta_range = np.arctan(self.lr / self.wheel_base * steer_range)
+
+        # Per-step yaw advance for the extreme steering angles. When a grip limit (grip) is
+        # set, cap the yaw magnitude like _step does (|phi_dot| <= grip / v).
+        yaw_step = last_speed / self.wheel_base * np.sin(beta_range) * dt
+        if grip is not None and last_speed > 0:
+            yaw_limit = grip / last_speed * dt
+            yaw_step = np.clip(yaw_step, -yaw_limit, yaw_limit)
+
+        # check that heading is in the range. heading_range may be larger than 2 * np.pi
+        heading_range = np.mod(last_state.heading + yaw_step, 2 * np.pi)
+        if (
+            heading_range[0] < heading_range[1]
+            and not heading_range[0] <= state.heading <= heading_range[1]
+        ):
+            return False
+        if heading_range[0] > heading_range[1] and not (
+            heading_range[0] <= state.heading or state.heading <= heading_range[1]
+        ):
+            return False
+
+        # check that speed is reachable within one step of the accel range (speed-clamped)
+        speed_end = np.clip(last_speed + np.array(self.accel_range) * dt, *self.speed_range)
+        if not speed_end[0] <= state.speed <= speed_end[1]:
+            return False
+
+        # check that the travel distance is plausible: the straight-line travel distance of
+        # a step (arc length) bounds the Euclidean displacement (chord <= arc), independent of
+        # steering.
+        d_lo = 0.5 * (last_speed + speed_end[0]) * dt
+        d_hi = 0.5 * (last_speed + speed_end[1]) * dt
+        travel_max = max(abs(last_speed * dt), abs(d_lo), abs(d_hi))
+        if math.hypot(state.x - last_state.x, state.y - last_state.y) > travel_max:
+            return False
 
         return True

--- a/tactics2d/physics/point_mass.py
+++ b/tactics2d/physics/point_mass.py
@@ -5,6 +5,7 @@
 
 
 import logging
+import math
 from typing import Tuple, Union
 
 import numpy as np
@@ -87,7 +88,7 @@ class PointMass(PhysicsModelBase):
 
         next_vx = vx + ax * dt
         next_vy = vy + ay * dt
-        next_speed = np.linalg.norm([next_vx, next_vy])
+        next_speed = math.hypot(next_vx, next_vy)
 
         # When the speed has not exceeded the constraint, the next state can be calculated directly.
         if self.speed_range is None or self.speed_range[0] <= next_speed <= self.speed_range[1]:
@@ -95,7 +96,7 @@ class PointMass(PhysicsModelBase):
                 frame=state.frame + interval,
                 x=state.x + vx * dt + 0.5 * ax * dt**2,
                 y=state.y + vy * dt + 0.5 * ay * dt**2,
-                heading=np.arctan2(next_vy, next_vx),
+                heading=math.atan2(next_vy, next_vx),
                 vx=next_vx,
                 vy=next_vy,
             )
@@ -108,23 +109,23 @@ class PointMass(PhysicsModelBase):
             c_ = vx**2 + vy**2 - self.speed_range[0] ** 2
 
             # Handle cases where a_ is very small (acceleration near zero)
-            if np.abs(a_) < 1e-12:
+            if abs(a_) < 1e-12:
                 # When acceleration is zero, use linear motion
-                if np.abs(b_) < 1e-12:
+                if abs(b_) < 1e-12:
                     # Both a_ and b_ are zero, velocity already at minimum speed
                     t1 = 0.0
                 else:
                     # Solve linear equation: b_ * t + c_ = 0
-                    t1 = -c_ / b_ if np.abs(b_) > 1e-12 else 0.0
+                    t1 = -c_ / b_ if abs(b_) > 1e-12 else 0.0
             else:
                 # Solve quadratic equation: a_ * t^2 + b_ * t + c_ = 0
                 discriminant = b_**2 - 4 * a_ * c_
                 # Ensure discriminant is non-negative (handle numerical errors)
                 discriminant = max(0.0, discriminant)
-                t1 = (-b_ - np.sqrt(discriminant)) / (2 * a_)
+                t1 = (-b_ - math.sqrt(discriminant)) / (2 * a_)
 
             # Ensure t1 is within [0, dt]
-            t1 = np.clip(t1, 0.0, dt)
+            t1 = max(0.0, min(t1, dt))
             t2 = dt - t1
             vx_min = vx + ax * t1
             vy_min = vy + ay * t1
@@ -133,7 +134,7 @@ class PointMass(PhysicsModelBase):
                 frame=state.frame + interval,
                 x=state.x + vx * t1 + 0.5 * ax * t1**2 + vx_min * t2,
                 y=state.y + vy * t1 + 0.5 * ay * t1**2 + vy_min * t2,
-                heading=np.arctan2(vy_min, vx_min),
+                heading=math.atan2(vy_min, vx_min),
                 vx=vx_min,
                 vy=vy_min,
             )
@@ -143,23 +144,23 @@ class PointMass(PhysicsModelBase):
             c_ = vx**2 + vy**2 - self.speed_range[1] ** 2
 
             # Handle cases where a_ is very small (acceleration near zero)
-            if np.abs(a_) < 1e-12:
+            if abs(a_) < 1e-12:
                 # When acceleration is zero, use linear motion
-                if np.abs(b_) < 1e-12:
+                if abs(b_) < 1e-12:
                     # Both a_ and b_ are zero, velocity already at maximum speed
                     t1 = 0.0
                 else:
                     # Solve linear equation: b_ * t + c_ = 0
-                    t1 = -c_ / b_ if np.abs(b_) > 1e-12 else 0.0
+                    t1 = -c_ / b_ if abs(b_) > 1e-12 else 0.0
             else:
                 # Solve quadratic equation: a_ * t^2 + b_ * t + c_ = 0
                 discriminant = b_**2 - 4 * a_ * c_
                 # Ensure discriminant is non-negative (handle numerical errors)
                 discriminant = max(0.0, discriminant)
-                t1 = (-b_ + np.sqrt(discriminant)) / (2 * a_)
+                t1 = (-b_ + math.sqrt(discriminant)) / (2 * a_)
 
             # Ensure t1 is within [0, dt]
-            t1 = np.clip(t1, 0.0, dt)
+            t1 = max(0.0, min(t1, dt))
             t2 = dt - t1
             vx_max = vx + ax * t1
             vy_max = vy + ay * t1
@@ -168,7 +169,7 @@ class PointMass(PhysicsModelBase):
                 frame=state.frame + interval,
                 x=state.x + vx * t1 + 0.5 * ax * t1**2 + vx_max * t2,
                 y=state.y + vy * t1 + 0.5 * ay * t1**2 + vy_max * t2,
-                heading=np.arctan2(vy_max, vx_max),
+                heading=math.atan2(vy_max, vx_max),
                 vx=vx_max,
                 vy=vy_max,
             )
@@ -184,21 +185,23 @@ class PointMass(PhysicsModelBase):
         if remainder > 0:
             dts.append(float(remainder) / 1000)
 
+        speed_range = self.speed_range
         for dt in dts:
             vx += ax * dt
             vy += ay * dt
-            speed = np.linalg.norm([vx, vy])
-            speed_clipped = (
-                np.clip(speed, *self.speed_range) if self.speed_range is not None else speed
-            )
+            speed = math.hypot(vx, vy)
+            if speed_range is not None:
+                speed_clipped = max(speed_range[0], min(speed, speed_range[1]))
+            else:
+                speed_clipped = speed
             # Use tolerance for floating point comparison
-            if np.abs(speed - speed_clipped) > 1e-12:
-                vx = speed_clipped * np.cos(heading)
-                vy = speed_clipped * np.sin(heading)
+            if abs(speed - speed_clipped) > 1e-12:
+                vx = speed_clipped * math.cos(heading)
+                vy = speed_clipped * math.sin(heading)
 
             x += vx * dt
             y += vy * dt
-            heading = np.arctan2(vy, vx)
+            heading = math.atan2(vy, vx)
 
         next_state = State(
             frame=state.frame + interval, x=x, y=y, heading=heading, vx=vx, vy=vy, ax=ax, ay=ay

--- a/tactics2d/physics/point_mass.py
+++ b/tactics2d/physics/point_mass.py
@@ -26,7 +26,7 @@ class PointMass(PhysicsModelBase):
         accel_range (Union[float, Tuple[float, float]]: The range of acceleration. The valid input is a float or a tuple of two floats represents (min acceleration, max acceleration). The unit is meter per second squared (m/s$^2$). The default value is None, which means no constraint on the acceleration. When the accel_range is negative or the min acceleration is not less than the max acceleration, the accel_range is set to None.
         interval (int): The time interval between the current state and the new state. The unit is millisecond. Defaults to None.
         delta_t (int): The discrete time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. It is recommended to keep delta_t smaller than 5 ms.
-        backend (str): The backend for the simulation. The default value is `newton`. The available choices are `newton` and `euler`. The `newton` backend is recommended because it is faster. The `euler` backend is used for comparison and testing purposes at currently. We plan to improve the `euler` backend in the future (maybe in version 1.1.0)
+        backend (str): The backend for the simulation. The default value is `newton`. The available choices are `newton` and `euler`. The `newton` backend is recommended because it is faster and handles speed constraints via a closed-form two-phase update. The `euler` backend integrates each sub-step exactly for the constant-acceleration ODE (equivalent to a 4th-order Runge-Kutta step, which is exact for this linear system), so it is equally insensitive to the time step; it is kept for comparison and testing.
     """
 
     backends = ["newton", "euler"]
@@ -187,20 +187,24 @@ class PointMass(PhysicsModelBase):
 
         speed_range = self.speed_range
         for dt in dts:
-            vx += ax * dt
-            vy += ay * dt
-            speed = math.hypot(vx, vy)
+            vx_next = vx + ax * dt
+            vy_next = vy + ay * dt
+            speed = math.hypot(vx_next, vy_next)
             if speed_range is not None:
                 speed_clipped = max(speed_range[0], min(speed, speed_range[1]))
             else:
                 speed_clipped = speed
             # Use tolerance for floating point comparison
             if abs(speed - speed_clipped) > 1e-12:
-                vx = speed_clipped * math.cos(heading)
-                vy = speed_clipped * math.sin(heading)
+                vx_next = speed_clipped * math.cos(heading)
+                vy_next = speed_clipped * math.sin(heading)
 
-            x += vx * dt
-            y += vy * dt
+            # Exact displacement for the constant-acceleration ODE over dt: the trapezoidal
+            # (midpoint) update equals a 4th-order Runge-Kutta step for this linear system
+            # and integrates the ballistic term exactly (x += vx*dt + 0.5*ax*dt**2).
+            x += 0.5 * (vx + vx_next) * dt
+            y += 0.5 * (vy + vy_next) * dt
+            vx, vy = vx_next, vy_next
             heading = math.atan2(vy, vx)
 
         next_state = State(

--- a/tactics2d/physics/single_track_drift.py
+++ b/tactics2d/physics/single_track_drift.py
@@ -4,6 +4,7 @@
 """Single track drift implementation."""
 
 
+import math
 from typing import Tuple, Union
 
 import numpy as np
@@ -195,8 +196,8 @@ class SingleTrackDrift(PhysicsModelBase):
         K_x = self.tire.p_kx1 * F_z
         B_x = K_x / (C_x * D_x + 1e-6)
 
-        F_x = D_x * np.sin(
-            C_x * np.arctan(B_x * kappa_x - E_x * (B_x * kappa_x - np.arctan(B_x * kappa_x))) + S_vx
+        F_x = D_x * math.sin(
+            C_x * math.atan(B_x * kappa_x - E_x * (B_x * kappa_x - math.atan(B_x * kappa_x))) + S_vx
         )
 
         return F_x
@@ -204,7 +205,8 @@ class SingleTrackDrift(PhysicsModelBase):
     def _pure_slip_lateral_tire_forces(
         self, alpha: float, gamma: float, F_z: float
     ) -> Tuple[float, float]:
-        S_hy = np.sign(gamma) * (self.tire.p_hy1 + self.tire.p_hy3 * np.abs(gamma))
+        sign_gamma = (gamma > 0) - (gamma < 0)  # np.sign semantics (0 for 0)
+        S_hy = sign_gamma * (self.tire.p_hy1 + self.tire.p_hy3 * abs(gamma))
         S_vy = S_hy * F_z
 
         alpha_y = alpha + S_hy
@@ -216,8 +218,8 @@ class SingleTrackDrift(PhysicsModelBase):
         K_y = self.tire.p_ky1 * F_z
         B_y = K_y / (C_y * D_y + 1e-6)
 
-        F_y = D_y * np.sin(
-            C_y * np.arctan(B_y * alpha_y - E_y * (B_y * alpha_y - np.arctan(B_y * alpha_y))) + S_vy
+        F_y = D_y * math.sin(
+            C_y * math.atan(B_y * alpha_y - E_y * (B_y * alpha_y - math.atan(B_y * alpha_y))) + S_vy
         )
 
         return F_y, mu_y
@@ -228,22 +230,22 @@ class SingleTrackDrift(PhysicsModelBase):
         S_hx_alpha = self.tire.r_hx1
         alpha_s = alpha + S_hx_alpha
 
-        B_x_alpha = self.tire.r_bx1 * np.cos(np.arctan(self.tire.r_bx2 * kappa))
+        B_x_alpha = self.tire.r_bx1 * math.cos(math.atan(self.tire.r_bx2 * kappa))
         C_x_alpha = self.tire.r_cx1
         E_x_alpha = self.tire.r_ex1
-        D_x_alpha = F0_x / np.cos(
+        D_x_alpha = F0_x / math.cos(
             C_x_alpha
-            * np.arctan(
+            * math.atan(
                 B_x_alpha * S_hx_alpha
-                - E_x_alpha * (B_x_alpha * S_hx_alpha - np.arctan(B_x_alpha * S_hx_alpha))
+                - E_x_alpha * (B_x_alpha * S_hx_alpha - math.atan(B_x_alpha * S_hx_alpha))
             )
         )
 
-        F_x = D_x_alpha * np.cos(
+        F_x = D_x_alpha * math.cos(
             C_x_alpha
-            * np.arctan(
+            * math.atan(
                 B_x_alpha * alpha_s
-                - E_x_alpha * (B_x_alpha * alpha_s - np.arctan(B_x_alpha * alpha_s))
+                - E_x_alpha * (B_x_alpha * alpha_s - math.atan(B_x_alpha * alpha_s))
             )
         )
 
@@ -253,14 +255,16 @@ class SingleTrackDrift(PhysicsModelBase):
         S_hy_kappa = self.tire.r_hy1
         kappa_s = kappa + S_hy_kappa
 
-        B_y_kappa = self.tire.r_by1 * np.cos(np.arctan(self.tire.r_by2 * (alpha - self.tire.r_by3)))
+        B_y_kappa = self.tire.r_by1 * math.cos(
+            math.atan(self.tire.r_by2 * (alpha - self.tire.r_by3))
+        )
         C_y_kappa = self.tire.r_cy1
         E_y_kappa = self.tire.r_ey1
-        D_y_kappa = F0_y / np.cos(
+        D_y_kappa = F0_y / math.cos(
             C_y_kappa
-            * np.arctan(
+            * math.atan(
                 B_y_kappa * S_hy_kappa
-                - E_y_kappa * (B_y_kappa * S_hy_kappa - np.arctan(B_y_kappa * S_hy_kappa))
+                - E_y_kappa * (B_y_kappa * S_hy_kappa - math.atan(B_y_kappa * S_hy_kappa))
             )
         )
 
@@ -268,17 +272,17 @@ class SingleTrackDrift(PhysicsModelBase):
             mu_y
             * F_z
             * (self.tire.r_vy1 + self.tire.r_vy3 * gamma)
-            * np.cos(np.arctan(self.tire.r_vy4 * alpha))
+            * math.cos(math.atan(self.tire.r_vy4 * alpha))
         )
-        S_vy_kappa = D_vy_kappa * np.sin(self.tire.r_vy5 * np.arctan(self.tire.r_vy6 * kappa))
+        S_vy_kappa = D_vy_kappa * math.sin(self.tire.r_vy5 * math.atan(self.tire.r_vy6 * kappa))
 
         F_y = (
             D_y_kappa
-            * np.cos(
+            * math.cos(
                 C_y_kappa
-                * np.arctan(
+                * math.atan(
                     B_y_kappa * kappa_s
-                    - E_y_kappa * (B_y_kappa * kappa_s - np.arctan(B_y_kappa * kappa_s))
+                    - E_y_kappa * (B_y_kappa * kappa_s - math.atan(B_y_kappa * kappa_s))
                 )
             )
             + S_vy_kappa
@@ -290,29 +294,30 @@ class SingleTrackDrift(PhysicsModelBase):
         self, v: float, delta: float, d_phi: float, beta: float, omega_wf: float, omega_wr: float
     ) -> Tuple[float, float, float, float]:
         # Use safe values to avoid division by zero
-        v_safe = v if np.abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
-        cos_beta = np.cos(beta)
-        cos_beta_safe = cos_beta if np.abs(cos_beta) > 1e-6 else (1e-6 if cos_beta >= 0 else -1e-6)
+        v_safe = v if abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
+        cos_beta = math.cos(beta)
+        cos_beta_safe = cos_beta if abs(cos_beta) > 1e-6 else (1e-6 if cos_beta >= 0 else -1e-6)
+        sin_beta = math.sin(beta)
 
         # compute lateral tire slip angles:
         alpha_f = (
-            np.arctan((v_safe * np.sin(beta) + d_phi * self.lf) / (v_safe * cos_beta_safe)) - delta
+            math.atan((v_safe * sin_beta + d_phi * self.lf) / (v_safe * cos_beta_safe)) - delta
         )
-        alpha_r = np.arctan((v_safe * np.sin(beta) - d_phi * self.lr) / (v_safe * cos_beta_safe))
+        alpha_r = math.atan((v_safe * sin_beta - d_phi * self.lr) / (v_safe * cos_beta_safe))
 
         # compute vertical tire forces
         F_zf = (self.mass * self._G * self.lr) / self.wheel_base
         F_zr = (self.mass * self._G * self.lf) / self.wheel_base
 
         # compute front and rear tire speeds with safe values
-        u_wf = v_safe * cos_beta_safe * np.cos(delta) + (
-            v_safe * np.sin(beta) + self.lf * d_phi
-        ) * np.sin(delta)
+        u_wf = v_safe * cos_beta_safe * math.cos(delta) + (
+            v_safe * sin_beta + self.lf * d_phi
+        ) * math.sin(delta)
         u_wr = v_safe * cos_beta_safe
 
         # protect against division by zero
-        u_wf_safe = u_wf if np.abs(u_wf) > 1e-6 else (1e-6 if u_wf >= 0 else -1e-6)
-        u_wr_safe = u_wr if np.abs(u_wr) > 1e-6 else (1e-6 if u_wr >= 0 else -1e-6)
+        u_wf_safe = u_wf if abs(u_wf) > 1e-6 else (1e-6 if u_wf >= 0 else -1e-6)
+        u_wr_safe = u_wr if abs(u_wr) > 1e-6 else (1e-6 if u_wr >= 0 else -1e-6)
 
         # compute longitudinal tire slip
         s_f = 1 - self.radius * omega_wf / u_wf_safe
@@ -353,11 +358,18 @@ class SingleTrackDrift(PhysicsModelBase):
         if remainder > 0:
             dts.append(float(remainder) / 1000)
 
+        # Loop-invariant terms: delta is constant across sub-steps.
+        tan_delta = math.tan(delta)
+        cos_delta = math.cos(delta)
+        sin_delta = math.sin(delta)
+        cos2_delta = cos_delta**2
+        denom2 = (1 + tan_delta * self.lr / self.wheel_base) ** 2
+
         x, y = state.location
         v = state.speed
         phi = state.heading
-        d_phi = v / self.wheel_base * np.tan(delta)
-        beta = np.arctan(self.lr / self.lf * np.tan(delta))  # slip angle
+        d_phi = v / self.wheel_base * tan_delta
+        beta = math.atan(self.lr / self.lf * tan_delta)  # slip angle
 
         if accel > 0:
             T_B = 0
@@ -366,42 +378,43 @@ class SingleTrackDrift(PhysicsModelBase):
             T_B = self.mass * self.radius * accel
             T_E = 0
 
+        speed_range = self.speed_range
         for dt in dts:
             # Use a safe velocity to avoid division by zero
-            v_safe = v if np.abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
+            v_safe = v if abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
 
             F_lf, F_lr, F_sf, F_sr = self._tire_forces(
                 v_safe, delta, d_phi, beta, omega_wf, omega_wr
             )
 
-            dx = v * np.cos(phi + beta)
-            dy = v * np.sin(phi + beta)
+            dx = v * math.cos(phi + beta)
+            dy = v * math.sin(phi + beta)
 
-            if np.abs(v) >= 0.1:
+            if abs(v) >= 0.1:
+                cos_delta_beta = math.cos(delta - beta)
+                sin_delta_beta = math.sin(delta - beta)
+                sin_beta = math.sin(beta)
+                cos_beta = math.cos(beta)
                 dv = (
                     1
                     / self.mass
                     * (
-                        -F_sf * np.sin(delta - beta)
-                        + F_sr * np.sin(beta)
-                        + F_lr * np.cos(beta)
-                        + F_lf * np.cos(delta - beta)
+                        -F_sf * sin_delta_beta
+                        + F_sr * sin_beta
+                        + F_lr * cos_beta
+                        + F_lf * cos_delta_beta
                     )
                 )
                 d_beta = -d_phi + 1 / (self.mass * v_safe) * (
-                    F_sf * np.cos(delta - beta)
-                    + F_sr * np.cos(beta)
-                    - F_lr * np.sin(beta)
-                    + F_lf * np.sin(delta - beta)
+                    F_sf * cos_delta_beta
+                    + F_sr * cos_beta
+                    - F_lr * sin_beta
+                    + F_lf * sin_delta_beta
                 )
                 dd_phi = (
                     1
                     / self.I_z
-                    * (
-                        F_sf * np.cos(delta) * self.lf
-                        - F_sr * self.lr
-                        + F_lf * np.sin(delta) * self.lf
-                    )
+                    * (F_sf * cos_delta * self.lf - F_sr * self.lr + F_lf * sin_delta * self.lf)
                 )
                 d_phi += dd_phi * dt
                 d_omega_wf = (
@@ -414,33 +427,25 @@ class SingleTrackDrift(PhysicsModelBase):
                 )
             else:
                 dv = accel
-                d_beta = (
-                    self.lr
-                    / (1 + np.tan(delta) * self.lr / self.wheel_base) ** 2
-                    / self.wheel_base
-                    / np.cos(delta) ** 2
-                    * delta
-                )
+                cos_beta = math.cos(beta)
+                sin_beta = math.sin(beta)
+                d_beta = self.lr / denom2 / self.wheel_base / cos2_delta * delta
                 dd_phi = (
                     1
                     / self.wheel_base
                     * (
-                        accel * np.cos(beta) * np.tan(delta)
-                        - v * np.sin(beta) * np.tan(delta) * d_beta
-                        + v * np.cos(beta) / np.cos(delta) ** 2 * delta
+                        accel * cos_beta * tan_delta
+                        - v * sin_beta * tan_delta * d_beta
+                        + v * cos_beta / cos2_delta * delta
                     )
                 )
-                d_phi += v * np.cos(beta) / self.wheel_base * np.tan(delta) * dt
+                d_phi += v * cos_beta / self.wheel_base * tan_delta * dt
                 d_omega_wf = (
                     1
-                    / (np.cos(delta) * self.radius)
-                    * (
-                        accel * np.cos(beta)
-                        - v * np.sin(beta) * d_beta
-                        + v * np.cos(beta) * np.tan(delta) * delta
-                    )
+                    / (cos_delta * self.radius)
+                    * (accel * cos_beta - v * sin_beta * d_beta + v * cos_beta * tan_delta * delta)
                 )
-                d_omega_wr = 1 / self.radius * (accel * np.cos(beta) - v * np.sin(beta) * d_beta)
+                d_omega_wr = 1 / self.radius * (accel * cos_beta - v * sin_beta * d_beta)
 
             x += dx * dt
             y += dy * dt
@@ -451,13 +456,17 @@ class SingleTrackDrift(PhysicsModelBase):
             omega_wf += d_omega_wf * dt
             omega_wr += d_omega_wr * dt
 
-            v = np.clip(v, *self.speed_range) if self.speed_range is not None else v
+            if speed_range is not None:
+                if v < speed_range[0]:
+                    v = speed_range[0]
+                elif v > speed_range[1]:
+                    v = speed_range[1]
 
         state = State(
             frame=state.frame + interval,
             x=x,
             y=y,
-            heading=np.mod(phi, 2 * np.pi),
+            heading=phi % (2 * math.pi),
             speed=v,
             accel=accel,
         )

--- a/tactics2d/physics/single_track_drift.py
+++ b/tactics2d/physics/single_track_drift.py
@@ -15,38 +15,46 @@ from .physics_model_base import PhysicsModelBase
 
 
 class Tire:
+    """Pacejka (magic-formula) tire coefficients from the ADAMS handbook.
+
+    The values match the CommonRoad tire parameter set (Althoff & Würsching, "CommonRoad:
+    Vehicle Models", 2020, Tab. 7). Compared to earlier Tactics2D releases, the combined-slip
+    coefficients ``r_cx1``/``r_ex1`` were swapped and several values were rounded; they are now
+    exact.
+    """
+
     # longitudinal parameters
     p_cx1 = 1.6411  # shape factor for longitudinal force
     p_dx1 = 1.1739  # longitudinal friction coefficient mu_x at F_z0
     p_dx3 = 0.0  # variation of friction coefficient mu_x with camber
-    p_ex1 = 0.4640  # longitudinal curvature at F_z0
+    p_ex1 = 0.46403  # longitudinal curvature at F_z0
     p_kx1 = 22.303  # longitudinal slip stiffness at F_z0
     p_hx1 = 1.2297e-3  # horizontal shift at F_z0
     p_vx1 = -8.8098e-6  # vertical shift at F_z0
     r_bx1 = 13.276  # slope factor for combined slip F_x reduction
     r_bx2 = -13.778  # variation of slope F_x reduction with kappa
-    r_ex1 = 1.2568  # shape factor for combined slip F_x reduction
-    r_cx1 = 0.6522  # curvature factor for combined F_x
+    r_cx1 = 1.2568  # shape factor for combined slip F_x reduction
+    r_ex1 = 0.65225  # curvature factor of combined F_x
     r_hx1 = 5.0722e-3  # shift factor for combined slip F_x reduction
     # lateral parameters
     p_cy1 = 1.3507  # shape factor for lateral force
     p_dy1 = 1.0489  # lateral friction coefficient mu_y
     p_dy3 = -2.8821  # variation of friction coefficient mu_y with squared camber
     p_ey1 = -7.4722e-3  # lateral curvature at F_z0
-    p_ky1 = -21.920  # maximum value of stiffness
+    p_ky1 = -21.92  # maximum value of stiffness
     p_hy1 = 2.6747e-3  # horizontal shift at F_z0
     p_hy3 = 3.1415e-2  # variation of shift with camber
     p_vy1 = 3.7318e-2  # vertical shift at F_z0
-    p_vy3 = -0.3293  # variation of vertical shift with camber
+    p_vy3 = -0.32931  # variation of vertical shift with camber
     r_by1 = 7.1433  # slope factor for combined slip F_y reduction
-    r_by2 = 9.1917  # variation of slope F_y reduction with alpha
+    r_by2 = 9.1916  # variation of slope F_y reduction with alpha
     r_by3 = -2.7856e-2  # shift term for alpha in slope F_y reduction
     r_cy1 = 1.0719  # shape factor for combined F_y reduction
-    r_ey1 = -0.2757  # curvature factor for combined F_y
+    r_ey1 = -0.27572  # curvature factor for combined F_y
     r_hy1 = 5.7448e-6  # shift factor for combined slip F_y reduction
     r_vy1 = -2.7825e-2  # kappa-induced side force at F_z0
-    r_vy3 = -0.2756  # variation of S_vy_kappa/mu_y F_z with camber
-    r_vy4 = 12.120  # variation of S_vy_kappa/mu_y F_z with alpha
+    r_vy3 = -0.27568  # variation of S_vy_kappa/mu_y F_z with camber
+    r_vy4 = 12.12  # variation of S_vy_kappa/mu_y F_z with alpha
     r_vy5 = 1.9  # variation of S_vy_kappa/mu_y F_z with kappa
     r_vy6 = -10.704  # variation of S_vy_kappa/mu_y F_z with arctan(kappa)
 
@@ -57,11 +65,24 @@ class SingleTrackDrift(PhysicsModelBase):
     !!! warning
         This class was designed "as a simplification of the multi-body" model. Theoretically, it is applicable to the All-Wheel-Drive (AWD) vehicle. However, the tire model is so complicated that it is not fully tested in `tactics2d` v1.0.0. The current implementation is based on the MATLAB code provided by the CommonRoad project. Please use it with caution.
 
+        The Pacejka tire dynamics are numerically stiff (a fast mode around 800 s$^{-1}$, so an
+        explicit 4th-order Runge-Kutta scheme is stable only below ~3.5 ms): keep `delta_t` at
+        1-2 ms for converged results.
+
     !!! quote "Reference"
         The dynamic single-track model is based on Chapter 8 of the following reference:
         [CommonRoad: Vehicle Models (2020a)](https://gitlab.lrz.de/tum-cps/commonroad-vehicle-models/-/blob/master/vehicleModels_commonRoad.pdf)
 
         Pacejka, Hans. *Tire and vehicle dynamics.* Elsevier, 2005.
+
+    !!! info "Parameter sources"
+        The default parameters are those of the CommonRoad reference vehicle (vehicle ID 1, a
+        Ford Escort): `I_z = 1538.85` kg·m$^2$, `I_yw = 1.7` kg·m$^2$, `radius = 0.344` m,
+        `T_sb = 0.76`, `T_se = 1.0`, and the Pacejka `Tire` coefficients from the ADAMS handbook
+        (Althoff & Würsching, "CommonRoad: Vehicle Models", 2020, Tab. 7). Vehicle mass and CG
+        height come from the participant template (e.g. `medium_car` is a Volkswagen Golf);
+        yaw/wheel inertias are not published for production cars, so the CommonRoad reference
+        vehicle is used — override them for a specific vehicle when known.
 
     Attributes:
         lf (float): The distance from the center of mass to the front axle. The unit is meter (m).
@@ -72,7 +93,7 @@ class SingleTrackDrift(PhysicsModelBase):
         T_sb (float): The split parameter between the front and rear axles for the braking torque. Defaults to 0.76.
         T_se (float): The split parameter between the front and rear axles for the engine torque. Defaults to 1.
         tire (Any): The tire model. Default to the in-built tire model.
-        I_z (float): The moment of inertia of the vehicle. The unit is kilogram meter squared (kg m^2). Defaults to 1500.
+        I_z (float): The moment of inertia of the vehicle. The unit is kilogram meter squared (kg m^2). Defaults to 1538.85.
         I_yw (float): The moment of inertia of the wheel. The unit is kilogram meter squared (kg m^2). Defaults to 1.7.
         steer_range (Union[float, Tuple[float, float]], optional): The steering angle range. The valid input is a float or a tuple of two floats represents (min steering angle, max steering angle). The unit is radian.
 
@@ -91,7 +112,7 @@ class SingleTrackDrift(PhysicsModelBase):
             - When the accel_range is a tuple, the acceleration is constrained to be within the range [min acceleration, max acceleration].
             - When the accel_range is negative or the min acceleration is not less than the max acceleration, the accel_range is set to None.
         interval (int, optional): The time interval between the current state and the new state. The unit is millisecond. Defaults to None.
-        delta_t (int, optional): The default time interval between the current state and the new state, 5 milliseconds (ms). Defaults to None.
+        delta_t (int, optional): The time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. The model integrates with a 4th-order Runge-Kutta scheme, but the Pacejka tire dynamics are stiff (explicit RK4 stable only below ~3.5 ms): keep delta_t at 1-2 ms for converged results.
     """
 
     def __init__(
@@ -104,7 +125,7 @@ class SingleTrackDrift(PhysicsModelBase):
         T_sb: float = 0.76,
         T_se: float = 1,
         tire=Tire(),
-        I_z: float = 1500,
+        I_z: float = 1538.85,
         I_yw: float = 1.7,
         steer_range: Union[float, Tuple[float, float]] = None,
         speed_range: Union[float, Tuple[float, float]] = None,
@@ -123,8 +144,8 @@ class SingleTrackDrift(PhysicsModelBase):
             T_sb (float): The split parameter between the front and rear axles for the braking torque.
             T_se (float): The split parameter between the front and rear axles for the engine torque.
             tire (Any): The tire model. The current implementation refers to the parameters in [CommonRoad: Vehicle Models (2020a)](https://gitlab.lrz.de/tum-cps/commonroad-vehicle-models/-/blob/master/vehicleModels_commonRoad.pdf). If you want to use a different tire model, you need to implement the tire model by yourself.
-            I_z (float): The moment of inertia of the vehicle. The unit is kilogram meter squared (kg m^2).
-            I_yw (float): The moment of inertia of the wheel. The unit is kilogram meter squared (kg m^2).
+            I_z (float): The moment of inertia of the vehicle. The unit is kilogram meter squared (kg m^2). Defaults to 1538.85.
+            I_yw (float): The moment of inertia of the wheel. The unit is kilogram meter squared (kg m^2). Defaults to 1.7.
             steer_range (Union[float, Tuple[float, float]], optional): The range of steering angle. The valid input is a positive float or a tuple of two floats represents (min steering angle, max steering angle). The unit is radian.
             speed_range (Union[float, Tuple[float, float]], optional): The range of speed. The valid input is a positive float or a tuple of two floats represents (min speed, max speed). The unit is meter per second (m/s).
             accel_range (Union[float, Tuple[float, float]], optional): The range of acceleration. The valid input is a positive float or a tuple of two floats represents (min acceleration, max acceleration). The unit is meter per second squared (m/s$^2$).
@@ -368,8 +389,15 @@ class SingleTrackDrift(PhysicsModelBase):
         x, y = state.location
         v = state.speed
         phi = state.heading
-        d_phi = v / self.wheel_base * tan_delta
-        beta = math.atan(self.lr / self.lf * tan_delta)  # slip angle
+        # d_phi (yaw rate) and beta (slip angle) are persistent states carried by the State
+        # object between step() calls; fall back to the kinematic initial condition when absent
+        # (e.g. a fresh State that was not produced by this model).
+        d_phi = state.yaw_rate if state.yaw_rate is not None else v / self.wheel_base * tan_delta
+        beta = (
+            state.slip_angle
+            if state.slip_angle is not None
+            else math.atan(self.lr / self.lf * tan_delta)
+        )
 
         if accel > 0:
             T_B = 0
@@ -379,18 +407,27 @@ class SingleTrackDrift(PhysicsModelBase):
             T_E = 0
 
         speed_range = self.speed_range
-        for dt in dts:
+
+        def _deriv(v, phi, beta, d_phi, omega_wf, omega_wr):
+            """Right-hand side of the drift ODE at a given state.
+
+            Returns (dx/dt, dy/dt, dv/dt, dphi/dt, dd_phi, d_beta, d_omega_wf, d_omega_wr),
+            treating d_phi, beta, omega_wf and omega_wr as state variables. The v >= 0.1
+            branch and the kinematic low-speed update of d_phi mirror the original
+            forward-Euler step (the locally-computed dd_phi is unused in the low-speed
+            branch, which advances d_phi by the kinematic yaw rate instead).
+            """
+            dx = v * math.cos(phi + beta)
+            dy = v * math.sin(phi + beta)
+            f_phi = d_phi
+
             # Use a safe velocity to avoid division by zero
             v_safe = v if abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
 
-            F_lf, F_lr, F_sf, F_sr = self._tire_forces(
-                v_safe, delta, d_phi, beta, omega_wf, omega_wr
-            )
-
-            dx = v * math.cos(phi + beta)
-            dy = v * math.sin(phi + beta)
-
             if abs(v) >= 0.1:
+                F_lf, F_lr, F_sf, F_sr = self._tire_forces(
+                    v_safe, delta, d_phi, beta, omega_wf, omega_wr
+                )
                 cos_delta_beta = math.cos(delta - beta)
                 sin_delta_beta = math.sin(delta - beta)
                 sin_beta = math.sin(beta)
@@ -416,7 +453,6 @@ class SingleTrackDrift(PhysicsModelBase):
                     / self.I_z
                     * (F_sf * cos_delta * self.lf - F_sr * self.lr + F_lf * sin_delta * self.lf)
                 )
-                d_phi += dd_phi * dt
                 d_omega_wf = (
                     1 / self.I_yw * (-self.radius * F_lf + self.T_sb * T_B + self.T_se * T_E)
                 )
@@ -430,16 +466,7 @@ class SingleTrackDrift(PhysicsModelBase):
                 cos_beta = math.cos(beta)
                 sin_beta = math.sin(beta)
                 d_beta = self.lr / denom2 / self.wheel_base / cos2_delta * delta
-                dd_phi = (
-                    1
-                    / self.wheel_base
-                    * (
-                        accel * cos_beta * tan_delta
-                        - v * sin_beta * tan_delta * d_beta
-                        + v * cos_beta / cos2_delta * delta
-                    )
-                )
-                d_phi += v * cos_beta / self.wheel_base * tan_delta * dt
+                dd_phi = v * cos_beta / self.wheel_base * tan_delta
                 d_omega_wf = (
                     1
                     / (cos_delta * self.radius)
@@ -447,14 +474,50 @@ class SingleTrackDrift(PhysicsModelBase):
                 )
                 d_omega_wr = 1 / self.radius * (accel * cos_beta - v * sin_beta * d_beta)
 
-            x += dx * dt
-            y += dy * dt
-            v += dv * dt
-            phi += d_phi * dt
-            beta += d_beta * dt
+            return dx, dy, dv, f_phi, dd_phi, d_beta, d_omega_wf, d_omega_wr
 
-            omega_wf += d_omega_wf * dt
-            omega_wr += d_omega_wr * dt
+        def _rk4_step(x, y, v, phi, d_phi, beta, omega_wf, omega_wr, h):
+            """Advance one sub-step of time h with a 4th-order Runge-Kutta scheme."""
+            k1 = _deriv(v, phi, beta, d_phi, omega_wf, omega_wr)
+            k2 = _deriv(
+                v + 0.5 * h * k1[2],
+                phi + 0.5 * h * k1[3],
+                beta + 0.5 * h * k1[5],
+                d_phi + 0.5 * h * k1[4],
+                omega_wf + 0.5 * h * k1[6],
+                omega_wr + 0.5 * h * k1[7],
+            )
+            k3 = _deriv(
+                v + 0.5 * h * k2[2],
+                phi + 0.5 * h * k2[3],
+                beta + 0.5 * h * k2[5],
+                d_phi + 0.5 * h * k2[4],
+                omega_wf + 0.5 * h * k2[6],
+                omega_wr + 0.5 * h * k2[7],
+            )
+            k4 = _deriv(
+                v + h * k3[2],
+                phi + h * k3[3],
+                beta + h * k3[5],
+                d_phi + h * k3[4],
+                omega_wf + h * k3[6],
+                omega_wr + h * k3[7],
+            )
+
+            x += h / 6.0 * (k1[0] + 2 * k2[0] + 2 * k3[0] + k4[0])
+            y += h / 6.0 * (k1[1] + 2 * k2[1] + 2 * k3[1] + k4[1])
+            v += h / 6.0 * (k1[2] + 2 * k2[2] + 2 * k3[2] + k4[2])
+            phi += h / 6.0 * (k1[3] + 2 * k2[3] + 2 * k3[3] + k4[3])
+            d_phi += h / 6.0 * (k1[4] + 2 * k2[4] + 2 * k3[4] + k4[4])
+            beta += h / 6.0 * (k1[5] + 2 * k2[5] + 2 * k3[5] + k4[5])
+            omega_wf += h / 6.0 * (k1[6] + 2 * k2[6] + 2 * k3[6] + k4[6])
+            omega_wr += h / 6.0 * (k1[7] + 2 * k2[7] + 2 * k3[7] + k4[7])
+            return x, y, v, phi, d_phi, beta, omega_wf, omega_wr
+
+        for dt in dts:
+            x, y, v, phi, d_phi, beta, omega_wf, omega_wr = _rk4_step(
+                x, y, v, phi, d_phi, beta, omega_wf, omega_wr, dt
+            )
 
             if speed_range is not None:
                 if v < speed_range[0]:
@@ -469,6 +532,8 @@ class SingleTrackDrift(PhysicsModelBase):
             heading=phi % (2 * math.pi),
             speed=v,
             accel=accel,
+            yaw_rate=d_phi,
+            slip_angle=beta,
         )
 
         return state, omega_wf, omega_wr
@@ -513,7 +578,8 @@ class SingleTrackDrift(PhysicsModelBase):
         """This function provides a very rough check for the state transition.
 
         !!! info
-        Uses the same rough check as the single track kinematics model.
+        Uses the shared single-track reachability check of `PhysicsModelBase` (same rough
+        check as the single track kinematics model).
 
         Args:
             state (State): The current state of the traffic participant.
@@ -523,43 +589,4 @@ class SingleTrackDrift(PhysicsModelBase):
         Returns:
             True if the new state is valid, False otherwise.
         """
-        interval = state.frame - last_state.frame if interval is None else interval
-        # Handle zero interval case
-        if interval == 0:
-            return True  # No time elapsed, state should be valid
-        dt = float(interval) / 1000
-        last_speed = last_state.speed
-
-        if None in [self.steer_range, self.speed_range, self.accel_range]:
-            return True
-
-        steer_range = np.array(self.steer_range)
-        beta_range = np.arctan(self.lr / self.wheel_base * steer_range)
-
-        # check that heading is in the range. heading_range may be larger than 2 * np.pi
-        heading_range = np.mod(
-            last_state.heading + last_speed / self.wheel_base * np.sin(beta_range) * dt, 2 * np.pi
-        )
-        if (
-            heading_range[0] < heading_range[1]
-            and not heading_range[0] <= state.heading <= heading_range[1]
-        ):
-            return False
-        if heading_range[0] > heading_range[1] and not (
-            heading_range[0] <= state.heading or state.heading <= heading_range[1]
-        ):
-            return False
-
-        # check that speed is in the range
-        speed_range = np.clip(last_speed + np.array(self.accel_range) * dt, *self.speed_range)
-        if not speed_range[0] <= state.speed <= speed_range[1]:
-            return False
-
-        # check that x, y are in the range
-        x_range = last_state.x + speed_range * np.cos(last_state.heading + beta_range) * dt
-        y_range = last_state.y + speed_range * np.sin(last_state.heading + beta_range) * dt
-
-        if not x_range[0] < state.x < x_range[1] or not y_range[0] < state.y < y_range[1]:
-            return False
-
-        return True
+        return self._verify_kinematic_state(state, last_state, interval)

--- a/tactics2d/physics/single_track_dynamics.py
+++ b/tactics2d/physics/single_track_dynamics.py
@@ -4,6 +4,7 @@
 """Single track dynamics implementation."""
 
 
+import math
 from typing import Tuple, Union
 
 import numpy as np
@@ -153,22 +154,28 @@ class SingleTrackDynamics(PhysicsModelBase):
         cf_factor_f = self.cf * factor_f
         cr_factor_r = self.cr * factor_r
 
+        # Loop-invariant terms: delta is constant across sub-steps.
+        tan_delta = math.tan(delta)
+        cos_delta = math.cos(delta)
+        cos2_delta = cos_delta**2
+        denom2 = (1 + tan_delta * self.lr / self.wheel_base) ** 2
+        speed_range = self.speed_range
+
         x, y = state.location
         phi = state.heading
         v = state.speed
-        d_phi = v / self.wheel_base * np.tan(delta)
-        beta = np.arctan(self.lr / self.lf * np.tan(delta))  # slip angle
+        d_phi = v / self.wheel_base * tan_delta
+        beta = math.atan(self.lr / self.lf * tan_delta)  # slip angle
 
         # Main steps with standard delta_t
         for _ in range(n_steps):
-            dx = v * np.cos(phi + beta)
-            dy = v * np.sin(phi + beta)
-            dv = accel
+            dx = v * math.cos(phi + beta)
+            dy = v * math.sin(phi + beta)
 
             # Use a safe velocity to avoid division by zero
-            v_safe = v if np.abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
+            v_safe = v if abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
 
-            if np.abs(v) >= 0.1:
+            if abs(v) >= 0.1:
                 dd_phi = (
                     self.mu
                     * self.mass
@@ -191,37 +198,37 @@ class SingleTrackDynamics(PhysicsModelBase):
                 )
                 d_phi += dd_phi * dt
             else:
-                d_beta = (
-                    self.lr
-                    / (1 + np.tan(delta) * self.lr / self.wheel_base) ** 2
-                    / self.wheel_base
-                    / np.cos(delta) ** 2
-                    * delta
-                )
+                cos_beta = math.cos(beta)
+                sin_beta = math.sin(beta)
+                d_beta = self.lr / denom2 / self.wheel_base / cos2_delta * delta
                 dd_phi = (
                     1
                     / self.wheel_base
                     * (
-                        accel * np.cos(beta) * np.tan(delta)
-                        - v * np.sin(beta) * np.tan(delta) * d_beta
-                        + v * np.cos(beta) / np.cos(delta) ** 2 * delta
+                        accel * cos_beta * tan_delta
+                        - v * sin_beta * tan_delta * d_beta
+                        + v * cos_beta / cos2_delta * delta
                     )
                 )
-                d_phi += v * np.cos(beta) / self.wheel_base * np.tan(delta) * dt
+                d_phi += v * cos_beta / self.wheel_base * tan_delta * dt
 
             x += dx * dt
             y += dy * dt
-            v += dv * dt
+            v += accel * dt
             phi += d_phi * dt
             beta += d_beta * dt
 
-            v = np.clip(v, *self.speed_range) if self.speed_range is not None else v
+            if speed_range is not None:
+                if v < speed_range[0]:
+                    v = speed_range[0]
+                elif v > speed_range[1]:
+                    v = speed_range[1]
 
         state = State(
             frame=state.frame + interval,
             x=x,
             y=y,
-            heading=np.mod(phi, 2 * np.pi),
+            heading=phi % (2 * math.pi),
             speed=v,
             accel=accel,
         )

--- a/tactics2d/physics/single_track_dynamics.py
+++ b/tactics2d/physics/single_track_dynamics.py
@@ -25,6 +25,13 @@ class SingleTrackDynamics(PhysicsModelBase):
         The dynamic single-track model is based on Chapter 7 of the following reference:
         [CommonRoad: Vehicle Models (2020a)](https://gitlab.lrz.de/tum-cps/commonroad-vehicle-models/-/blob/master/vehicleModels_commonRoad.pdf)
 
+    !!! info "Parameter sources"
+        Defaults follow CommonRoad: Vehicle Models (2020a), vehicle ID 1 (Ford Escort):
+        `I_z = 1538.85` kg·m$^2$; cornering stiffness `cf = cr = 20.89` rad$^{-1}$ is derived
+        from the Pacejka tire data as `-p_ky1 / p_dy1`; `mu` is a physical tire-road friction
+        coefficient (see the attribute docs). `lf`, `lr`, `mass` and `mass_height` come from the
+        participant template.
+
     Attributes:
         lf (float): The distance from the geometry center to the front axle center. The unit is meter.
         lr (float): The distance from the geometry center to the rear axle center. The unit is meter.
@@ -36,10 +43,11 @@ class SingleTrackDynamics(PhysicsModelBase):
 
         mass (float): The mass of the vehicle. The unit is kilogram.
         mass_height (float): The height of the center of mass from the ground. The unit is meter.
-        mu (float): The friction coefficient. It is a dimensionless quantity. Defaults to 0.7.
-        I_z (float): The moment of inertia of the vehicle. The unit is kilogram per meter squared (kg/m$^2$). Defaults to 1500.
-        cf (float): The cornering stiffness of the front wheel. The unit is 1/rad. Defaults to 20.89.
-        cr (float): The cornering stiffness of the rear wheel. The unit is 1/rad. Defaults to 20.89.
+        mu (float): The friction coefficient. It is a dimensionless quantity. Defaults to 0.7. This is a physical tire-road friction coefficient (dry asphalt ≈ 0.7–0.9); the CommonRoad ST model this class is based on uses the magic-formula ``p_dy1`` (1.0489) in its place, so set ``mu = p_dy1`` to match the reference exactly.
+        friction_ellipse (bool): Whether to couple longitudinal and lateral grip through a friction ellipse. Defaults to False. When enabled, the lateral-response coefficient used by the high-speed branch is reduced to ``mu * sqrt(1 - (a / (mu * g))**2)``, so accelerating or braking consumes part of the available friction and full-throttle/hard-brake manoeuvres (|a| >= mu * g) leave no lateral capability; at a = 0 the behaviour is unchanged.
+        I_z (float): The moment of inertia of the vehicle. The unit is kilogram per meter squared (kg/m$^2$). Defaults to 1538.85 (CommonRoad vehicle ID 1, Ford Escort).
+        cf (float): The cornering stiffness of the front wheel. The unit is 1/rad. Defaults to 20.89 (= -p_ky1/p_dy1 derived from the Pacejka tire data).
+        cr (float): The cornering stiffness of the rear wheel. The unit is 1/rad. Defaults to 20.89 (= -p_ky1/p_dy1 derived from the Pacejka tire data).
 
         speed_range (Union[float, Tuple[float, float]], optional): The speed range. The valid input is a float or a tuple of two floats represents (min speed, max speed). The unit is meter per second (m/s).
             - When the speed_range is a non-negative float, the speed is constrained to be within the range [-speed_range, speed_range].
@@ -53,7 +61,7 @@ class SingleTrackDynamics(PhysicsModelBase):
             - When the accel_range is negative or the min acceleration is not less than the max acceleration, the accel_range is set to None.
 
         interval (int, optional): The time interval between the current state and the new state. The unit is millisecond. Defaults to None.
-        delta_t (int, optional): The time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. It is recommended to keep delta_t smaller than 5 ms.
+        delta_t (int, optional): The time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. The model integrates with a 4th-order Runge-Kutta scheme, so discretization error stays negligible up to ~20 ms; the default 5 ms is retained for backward compatibility.
     """
 
     def __init__(
@@ -63,7 +71,8 @@ class SingleTrackDynamics(PhysicsModelBase):
         mass: float,
         mass_height: float,
         mu: float = 0.7,
-        I_z: float = 1500,
+        friction_ellipse: bool = False,
+        I_z: float = 1538.85,
         cf: float = 20.89,
         cr: float = 20.89,
         steer_range: Union[float, Tuple[float, float]] = None,
@@ -80,6 +89,7 @@ class SingleTrackDynamics(PhysicsModelBase):
             mass (float): The mass of the vehicle. The unit is kilogram. You can use the curb weight of the vehicle as an approximation.
             mass_height (float): The height of the center of mass from the ground. The unit is meter. You can use half of the vehicle height as an approximation.
             mu (float): The friction coefficient. It is a dimensionless quantity.
+            friction_ellipse (bool): Whether to couple longitudinal and lateral grip through a friction ellipse. Defaults to False. When True, the lateral-response coefficient used by the high-speed branch is reduced to ``mu * sqrt(1 - (a / (mu * g))**2)``.
             I_z (float): The moment of inertia of the vehicle. The unit is kilogram per meter squared (kg/m$^2$).
             cf (float): The cornering stiffness of the front wheel. The unit is 1/rad.
             cr (float): The cornering stiffness of the rear wheel. The unit is 1/rad.
@@ -95,6 +105,7 @@ class SingleTrackDynamics(PhysicsModelBase):
         self.mass = mass
         self.mass_height = mass_height
         self.mu = mu
+        self.friction_ellipse = friction_ellipse
         self.I_z = I_z
         self.cf = cf
         self.cr = cr
@@ -146,6 +157,16 @@ class SingleTrackDynamics(PhysicsModelBase):
         factor_f = (self._G * self.lr - accel * self.mass_height) / self.wheel_base
         factor_r = (self._G * self.lf + accel * self.mass_height) / self.wheel_base
 
+        # Friction-ellipse coupling: when enabled, longitudinal acceleration consumes part of
+        # the available friction, so the lateral-response coefficient is reduced to
+        #   mu * sqrt(1 - (a / (mu * g))^2)
+        # (0 when |a| >= mu * g). accel is constant within one step(), so mu_lat is constant.
+        if self.friction_ellipse and self.mu > 0:
+            _ratio = accel / (self.mu * self._G)
+            mu_lat = self.mu * math.sqrt(max(0.0, 1.0 - _ratio * _ratio))
+        else:
+            mu_lat = self.mu
+
         # Precompute constant combinations for efficiency
         lf_cf_factor_f = self.lf * self.cf * factor_f
         lr_cr_factor_r = self.lr * self.cr * factor_r
@@ -164,20 +185,32 @@ class SingleTrackDynamics(PhysicsModelBase):
         x, y = state.location
         phi = state.heading
         v = state.speed
-        d_phi = v / self.wheel_base * tan_delta
-        beta = math.atan(self.lr / self.lf * tan_delta)  # slip angle
+        # d_phi (yaw rate) and beta (slip angle) are persistent states carried by the State
+        # object between step() calls; fall back to the kinematic initial condition when absent.
+        d_phi = state.yaw_rate if state.yaw_rate is not None else v / self.wheel_base * tan_delta
+        beta = (
+            state.slip_angle
+            if state.slip_angle is not None
+            else math.atan(self.lr / self.lf * tan_delta)
+        )
 
-        # Main steps with standard delta_t
-        for _ in range(n_steps):
+        def _deriv(v, phi, beta, d_phi):
+            """Right-hand side of the dynamics ODE at a given state.
+
+            Returns (dx/dt, dy/dt, dphi/dt, dv/dt, dd_phi, d_beta), treating d_phi and beta
+            as state variables with time derivatives dd_phi and d_beta.
+            """
             dx = v * math.cos(phi + beta)
             dy = v * math.sin(phi + beta)
+            f_phi = d_phi
+            f_v = accel
 
             # Use a safe velocity to avoid division by zero
             v_safe = v if abs(v) > 1e-6 else (1e-6 if v >= 0 else -1e-6)
 
             if abs(v) >= 0.1:
                 dd_phi = (
-                    self.mu
+                    mu_lat
                     * self.mass
                     / self.I_z
                     * (
@@ -187,7 +220,7 @@ class SingleTrackDynamics(PhysicsModelBase):
                     )
                 )
                 d_beta = (
-                    self.mu
+                    mu_lat
                     / v_safe
                     * (
                         cf_factor_f * delta
@@ -196,7 +229,6 @@ class SingleTrackDynamics(PhysicsModelBase):
                     )
                     - d_phi
                 )
-                d_phi += dd_phi * dt
             else:
                 cos_beta = math.cos(beta)
                 sin_beta = math.sin(beta)
@@ -210,13 +242,49 @@ class SingleTrackDynamics(PhysicsModelBase):
                         + v * cos_beta / cos2_delta * delta
                     )
                 )
-                d_phi += v * cos_beta / self.wheel_base * tan_delta * dt
 
-            x += dx * dt
-            y += dy * dt
-            v += accel * dt
-            phi += d_phi * dt
-            beta += d_beta * dt
+            return dx, dy, f_phi, f_v, dd_phi, d_beta
+
+        def _rk4_step(x, y, phi, v, d_phi, beta, h):
+            """Advance one sub-step of time h with a 4th-order Runge-Kutta scheme."""
+            k1 = _deriv(v, phi, beta, d_phi)
+            k2 = _deriv(
+                v + 0.5 * h * k1[3],
+                phi + 0.5 * h * k1[2],
+                beta + 0.5 * h * k1[5],
+                d_phi + 0.5 * h * k1[4],
+            )
+            k3 = _deriv(
+                v + 0.5 * h * k2[3],
+                phi + 0.5 * h * k2[2],
+                beta + 0.5 * h * k2[5],
+                d_phi + 0.5 * h * k2[4],
+            )
+            k4 = _deriv(v + h * k3[3], phi + h * k3[2], beta + h * k3[5], d_phi + h * k3[4])
+
+            x += h / 6.0 * (k1[0] + 2 * k2[0] + 2 * k3[0] + k4[0])
+            y += h / 6.0 * (k1[1] + 2 * k2[1] + 2 * k3[1] + k4[1])
+            phi += h / 6.0 * (k1[2] + 2 * k2[2] + 2 * k3[2] + k4[2])
+            v += h / 6.0 * (k1[3] + 2 * k2[3] + 2 * k3[3] + k4[3])
+            d_phi += h / 6.0 * (k1[4] + 2 * k2[4] + 2 * k3[4] + k4[4])
+            beta += h / 6.0 * (k1[5] + 2 * k2[5] + 2 * k3[5] + k4[5])
+            return x, y, phi, v, d_phi, beta
+
+        # Main steps with standard delta_t
+        for _ in range(n_steps):
+            x, y, phi, v, d_phi, beta = _rk4_step(x, y, phi, v, d_phi, beta, dt)
+
+            if speed_range is not None:
+                if v < speed_range[0]:
+                    v = speed_range[0]
+                elif v > speed_range[1]:
+                    v = speed_range[1]
+
+        # Remainder step if any
+        if remainder > 0:
+            x, y, phi, v, d_phi, beta = _rk4_step(
+                x, y, phi, v, d_phi, beta, float(remainder) / 1000
+            )
 
             if speed_range is not None:
                 if v < speed_range[0]:
@@ -231,6 +299,8 @@ class SingleTrackDynamics(PhysicsModelBase):
             heading=phi % (2 * math.pi),
             speed=v,
             accel=accel,
+            yaw_rate=d_phi,
+            slip_angle=beta,
         )
 
         return state
@@ -261,7 +331,8 @@ class SingleTrackDynamics(PhysicsModelBase):
         """This function provides a very rough check for the state transition.
 
         !!! info
-        Uses the same rough check as the single track kinematics model.
+        Uses the shared single-track reachability check of `PhysicsModelBase` (same rough
+        check as the single track kinematics model).
 
         Args:
             state (State): The current state of the traffic participant.
@@ -271,43 +342,4 @@ class SingleTrackDynamics(PhysicsModelBase):
         Returns:
             True if the new state is valid, False otherwise.
         """
-        interval = state.frame - last_state.frame if interval is None else interval
-        # Handle zero interval case
-        if interval == 0:
-            return True  # No time elapsed, state should be valid
-        dt = float(interval) / 1000
-        last_speed = last_state.speed
-
-        if None in [self.steer_range, self.speed_range, self.accel_range]:
-            return True
-
-        steer_range = np.array(self.steer_range)
-        beta_range = np.arctan(self.lr / self.wheel_base * steer_range)
-
-        # check that heading is in the range. heading_range may be larger than 2 * np.pi
-        heading_range = np.mod(
-            last_state.heading + last_speed / self.wheel_base * np.sin(beta_range) * dt, 2 * np.pi
-        )
-        if (
-            heading_range[0] < heading_range[1]
-            and not heading_range[0] <= state.heading <= heading_range[1]
-        ):
-            return False
-        if heading_range[0] > heading_range[1] and not (
-            heading_range[0] <= state.heading or state.heading <= heading_range[1]
-        ):
-            return False
-
-        # check that speed is in the range
-        speed_range = np.clip(last_speed + np.array(self.accel_range) * dt, *self.speed_range)
-        if not speed_range[0] <= state.speed <= speed_range[1]:
-            return False
-
-        # check that x, y are in the range
-        x_range = last_state.x + speed_range * np.cos(last_state.heading + beta_range) * dt
-        y_range = last_state.y + speed_range * np.sin(last_state.heading + beta_range) * dt
-
-        if not x_range[0] < state.x < x_range[1] or not y_range[0] < state.y < y_range[1]:
-            return False
-
-        return True
+        return self._verify_kinematic_state(state, last_state, interval)

--- a/tactics2d/physics/single_track_kinematics.py
+++ b/tactics2d/physics/single_track_kinematics.py
@@ -4,6 +4,7 @@
 """Single track kinematics implementation."""
 
 
+import math
 from typing import Tuple, Union
 
 import numpy as np
@@ -124,10 +125,15 @@ class SingleTrackKinematics(PhysicsModelBase):
                 self.delta_t = min(self.delta_t, self.interval)
 
     def _step(self, state: State, accel: float, delta: float, interval: int) -> State:
-        beta = np.arctan(self.lr / self.wheel_base * np.tan(delta))  # slip angle
+        beta = math.atan(self.lr / self.wheel_base * math.tan(delta))  # slip angle
         dt = float(self.delta_t) / 1000
         n_steps = interval // self.delta_t
         remainder = interval % self.delta_t
+
+        # Loop-invariant terms: delta and beta are constant across sub-steps.
+        cos_beta = math.cos(beta)
+        k_phi = math.tan(delta) * cos_beta / self.wheel_base
+        speed_range = self.speed_range
 
         x, y = state.location
         phi = state.heading
@@ -135,40 +141,46 @@ class SingleTrackKinematics(PhysicsModelBase):
 
         # Main steps with standard delta_t
         for _ in range(n_steps):
-            dx = v * np.cos(phi + beta)
-            dy = v * np.sin(phi + beta)
-            dv = accel
-            dphi = v / self.wheel_base * np.tan(delta) * np.cos(beta)
+            dx = v * math.cos(phi + beta)
+            dy = v * math.sin(phi + beta)
+            dphi = v * k_phi
 
             x += dx * dt
             y += dy * dt
             phi += dphi * dt
-            v += dv * dt
+            v += accel * dt
 
-            v = np.clip(v, *self.speed_range) if self.speed_range is not None else v
+            if speed_range is not None:
+                if v < speed_range[0]:
+                    v = speed_range[0]
+                elif v > speed_range[1]:
+                    v = speed_range[1]
 
         # Remainder step if any
         if remainder > 0:
             dt_rem = float(remainder) / 1000
-            dx = v * np.cos(phi + beta)
-            dy = v * np.sin(phi + beta)
-            dv = accel
-            dphi = v / self.wheel_base * np.tan(delta) * np.cos(beta)
+            dx = v * math.cos(phi + beta)
+            dy = v * math.sin(phi + beta)
+            dphi = v * k_phi
 
             x += dx * dt_rem
             y += dy * dt_rem
             phi += dphi * dt_rem
-            v += dv * dt_rem
+            v += accel * dt_rem
 
-            v = np.clip(v, *self.speed_range) if self.speed_range is not None else v
+            if speed_range is not None:
+                if v < speed_range[0]:
+                    v = speed_range[0]
+                elif v > speed_range[1]:
+                    v = speed_range[1]
 
         state = State(
             frame=state.frame + interval,
             x=x,
             y=y,
-            heading=np.mod(phi, 2 * np.pi),
-            vx=v * np.cos(phi),
-            vy=v * np.sin(phi),
+            heading=phi % (2 * math.pi),
+            vx=v * math.cos(phi),
+            vy=v * math.sin(phi),
             speed=v,
             accel=accel,
         )

--- a/tactics2d/physics/single_track_kinematics.py
+++ b/tactics2d/physics/single_track_kinematics.py
@@ -34,11 +34,18 @@ class SingleTrackKinematics(PhysicsModelBase):
         Kong, Jason, et al. "Kinematic and dynamic vehicle models for autonomous driving control design." *2015 IEEE intelligent vehicles symposium* (IV). IEEE, 2015.
 
     !!! warning
-        This model will lose its accuracy when the time step is set too large or the traffic participant is made to travel at a high speed.
+        This model integrates the equations of motion with a 4th-order Runge-Kutta scheme, so the
+        discretization error stays negligible for delta_t up to about 50 ms. Use a smaller delta_t
+        (the default 5 ms) when maximum fidelity to the continuous model is required.
 
     Attributes:
         lf (float): The distance from the geometry center to the front axle center. The unit is meter.
         lr (float): The distance from the geometry center to the rear axle center. The unit is meter.
+        mu (float, optional): The tire-road friction coefficient. Defaults to None. It is a dimensionless quantity.
+
+            - When `mu` is None (default), the model is the pure no-slip kinematic bicycle: it assumes unlimited grip and reproduces the CommonRoad kinematic single-track reference exactly.
+            - When `mu` is set (e.g. 0.85 for dry asphalt), the turn rate is capped so the demanded lateral acceleration `a_y = v * phi_dot` stays within `mu * g`, i.e. the curvature is reduced to the grip-limit value and the vehicle understeers once the friction limit is reached. This removes the kinematic model's "unlimited grip" assumption at the cost of an extra piecewise (soft) nonlinearity; use a smaller `delta_t` for fine accuracy near the limit.
+
         steer_range (Union[float, Tuple[float, float]], optional): The steering angle range. The valid input is a float or a tuple of two floats represents (min steering angle, max steering angle). The unit is radian.
 
             - When the steer_range is a non-negative float, the steering angle is constrained to be within the range [-steer_range, steer_range].
@@ -57,13 +64,14 @@ class SingleTrackKinematics(PhysicsModelBase):
             - When the accel_range is negative or the min acceleration is not less than the max acceleration, the accel_range is set to None.
 
         interval (int, optional): The time interval between the current state and the new state. The unit is millisecond. Defaults to None.
-        delta_t (int, optional): The time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. It is recommended to keep delta_t smaller than 5 ms.
+        delta_t (int, optional): The time step for the simulation. The unit is millisecond. Defaults to `_DELTA_T`(5 ms). The expected value is between `_MIN_DELTA_T`(1 ms) and `interval`. The model integrates with a 4th-order Runge-Kutta scheme, so discretization error stays negligible up to ~50 ms; the default 5 ms is retained for backward compatibility.
     """
 
     def __init__(
         self,
         lf: float,
         lr: float,
+        mu: float = None,
         steer_range: Union[float, Tuple[float, float]] = None,
         speed_range: Union[float, Tuple[float, float]] = None,
         accel_range: Union[float, Tuple[float, float]] = None,
@@ -75,6 +83,7 @@ class SingleTrackKinematics(PhysicsModelBase):
         Args:
             lf (float): The distance from the center of mass to the front axle center. The unit is meter.
             lr (float): The distance from the center of mass to the rear axle center. The unit is meter.
+            mu (float, optional): The tire-road friction coefficient. It is a dimensionless quantity. Defaults to None. When set, the turn rate is capped so the lateral acceleration stays within `mu * g` (grip limit); when None (default), the pure no-slip kinematic model is used (unlimited grip, matches the CommonRoad reference exactly).
             steer_range (Union[float, Tuple[float, float]], optional): The range of steering angle. The valid input is a positive float or a tuple of two floats represents (min steering angle, max steering angle). The unit is radian.
             speed_range (Union[float, Tuple[float, float]], optional): The range of speed. The valid input is a positive float or a tuple of two floats represents (min speed, max speed). The unit is meter per second (m/s).
             accel_range (Union[float, Tuple[float, float]], optional): The range of acceleration. The valid input is a positive float or a tuple of two floats represents (min acceleration, max acceleration). The unit is meter per second squared (m/s$^2$).
@@ -84,6 +93,7 @@ class SingleTrackKinematics(PhysicsModelBase):
         self.lf = lf
         self.lr = lr
         self.wheel_base = lf + lr
+        self.mu = mu
 
         if isinstance(steer_range, float):
             self.steer_range = None if steer_range < 0 else [-steer_range, steer_range]
@@ -135,20 +145,70 @@ class SingleTrackKinematics(PhysicsModelBase):
         k_phi = math.tan(delta) * cos_beta / self.wheel_base
         speed_range = self.speed_range
 
+        # Grip limit (mu * g) in m/s^2, if a friction coefficient was supplied.
+        mu_g = None if self.mu is None else self.mu * self._G
+
+        def _turn_rate(v):
+            """Yaw rate at speed ``v``, capped so the lateral acceleration v * phi_dot
+            stays within mu * g when a grip limit is set. Without a limit (mu=None) or at
+            zero/negative speed this is the pure geometric rate v * k_phi, so the default
+            model reproduces the reference kinematics exactly.
+            """
+            rate = v * k_phi
+            if mu_g is None or v <= 0.0:
+                return rate
+            limit = mu_g / v
+            if rate > limit:
+                return limit
+            if rate < -limit:
+                return -limit
+            return rate
+
+        def _rk4_step(x, y, phi, v, h):
+            """Advance one sub-step of time h with a 4th-order Runge-Kutta scheme.
+
+            The equations of motion are
+                dx/dt = v * cos(phi + beta), dy/dt = v * sin(phi + beta),
+                dphi/dt = turn_rate(v), dv/dt = accel.
+            Since dv/dt is constant, its stage slopes are identical and the velocity
+            update reduces to v += accel * h (integrated exactly).
+            """
+            # Stage 1
+            k1x = v * math.cos(phi + beta)
+            k1y = v * math.sin(phi + beta)
+            k1p = v * k_phi if mu_g is None else _turn_rate(v)
+            # Stage 2
+            v2 = v + 0.5 * h * accel
+            p2 = phi + 0.5 * h * k1p
+            k2x = v2 * math.cos(p2 + beta)
+            k2y = v2 * math.sin(p2 + beta)
+            k2p = v2 * k_phi if mu_g is None else _turn_rate(v2)
+            # Stage 3
+            v3 = v + 0.5 * h * accel
+            p3 = phi + 0.5 * h * k2p
+            k3x = v3 * math.cos(p3 + beta)
+            k3y = v3 * math.sin(p3 + beta)
+            k3p = v3 * k_phi if mu_g is None else _turn_rate(v3)
+            # Stage 4
+            v4 = v + h * accel
+            p4 = phi + h * k3p
+            k4x = v4 * math.cos(p4 + beta)
+            k4y = v4 * math.sin(p4 + beta)
+            k4p = v4 * k_phi if mu_g is None else _turn_rate(v4)
+
+            x += h / 6.0 * (k1x + 2 * k2x + 2 * k3x + k4x)
+            y += h / 6.0 * (k1y + 2 * k2y + 2 * k3y + k4y)
+            phi += h / 6.0 * (k1p + 2 * k2p + 2 * k3p + k4p)
+            v += h * accel
+            return x, y, phi, v
+
         x, y = state.location
         phi = state.heading
         v = state.speed
 
         # Main steps with standard delta_t
         for _ in range(n_steps):
-            dx = v * math.cos(phi + beta)
-            dy = v * math.sin(phi + beta)
-            dphi = v * k_phi
-
-            x += dx * dt
-            y += dy * dt
-            phi += dphi * dt
-            v += accel * dt
+            x, y, phi, v = _rk4_step(x, y, phi, v, dt)
 
             if speed_range is not None:
                 if v < speed_range[0]:
@@ -158,15 +218,7 @@ class SingleTrackKinematics(PhysicsModelBase):
 
         # Remainder step if any
         if remainder > 0:
-            dt_rem = float(remainder) / 1000
-            dx = v * math.cos(phi + beta)
-            dy = v * math.sin(phi + beta)
-            dphi = v * k_phi
-
-            x += dx * dt_rem
-            y += dy * dt_rem
-            phi += dphi * dt_rem
-            v += accel * dt_rem
+            x, y, phi, v = _rk4_step(x, y, phi, v, float(remainder) / 1000)
 
             if speed_range is not None:
                 if v < speed_range[0]:
@@ -212,6 +264,9 @@ class SingleTrackKinematics(PhysicsModelBase):
     def verify_state(self, state: State, last_state: State, interval: int = None) -> bool:
         """This function provides a very rough check for the state transition.
 
+        Uses the shared single-track reachability check of `PhysicsModelBase`; when a grip
+        limit (`mu`) is set the extreme-steer heading advance is capped like in `_step`.
+
         Args:
             state (State): The current state of the traffic participant.
             last_state (State): The last state of the traffic participant.
@@ -220,43 +275,6 @@ class SingleTrackKinematics(PhysicsModelBase):
         Returns:
             True if the new state is valid, False otherwise.
         """
-        interval = state.frame - last_state.frame if interval is None else interval
-        # Handle zero interval case
-        if interval == 0:
-            return True  # No time elapsed, state should be valid
-        dt = float(interval) / 1000
-        last_speed = last_state.speed
-
-        if None in [self.steer_range, self.speed_range, self.accel_range]:
-            return True
-
-        steer_range = np.array(self.steer_range)
-        beta_range = np.arctan(self.lr / self.wheel_base * steer_range)
-
-        # check that heading is in the range. heading_range may be larger than 2 * np.pi
-        heading_range = np.mod(
-            last_state.heading + last_speed / self.wheel_base * np.sin(beta_range) * dt, 2 * np.pi
+        return self._verify_kinematic_state(
+            state, last_state, interval, grip=(self.mu * self._G if self.mu is not None else None)
         )
-        if (
-            heading_range[0] < heading_range[1]
-            and not heading_range[0] <= state.heading <= heading_range[1]
-        ):
-            return False
-        if heading_range[0] > heading_range[1] and not (
-            heading_range[0] <= state.heading or state.heading <= heading_range[1]
-        ):
-            return False
-
-        # check that speed is in the range
-        speed_range = np.clip(last_speed + np.array(self.accel_range) * dt, *self.speed_range)
-        if not speed_range[0] <= state.speed <= speed_range[1]:
-            return False
-
-        # check that x, y are in the range
-        x_range = last_state.x + speed_range * np.cos(last_state.heading + beta_range) * dt
-        y_range = last_state.y + speed_range * np.sin(last_state.heading + beta_range) * dt
-
-        if not x_range[0] < state.x < x_range[1] or not y_range[0] < state.y < y_range[1]:
-            return False
-
-        return True

--- a/tactics2d/routing/utils.py
+++ b/tactics2d/routing/utils.py
@@ -60,27 +60,37 @@ def concatenate_centerlines(centerlines: Iterable[np.ndarray]) -> Optional[np.nd
 
 
 def find_nearest_lane(
-    map_: Map, point_xy: Sequence[float], candidate_lane_ids: Optional[Iterable[str]] = None
+    map_: Map,
+    point_xy: Sequence[float],
+    candidate_lane_ids: Optional[Iterable[str]] = None,
+    search_radius: float = 20.0,
 ) -> Optional[str]:
-    """Find the nearest lane to a point."""
+    """Find the nearest lane to a point.
+
+    When ``candidate_lane_ids`` is not given, the map's spatial index narrows
+    the search to lanes whose geometry lies within ``search_radius`` of the
+    point; a full scan is used as a fallback when no index is available or no
+    lane is that close (so a far-away nearest lane is still found).
+    """
 
     point = Point(point_xy[0], point_xy[1])
     best_lane_id = None
     best_distance = np.inf
 
-    if candidate_lane_ids is None:
-        lane_ids = list(map_.lanes.keys())
-    else:
+    if candidate_lane_ids is not None:
         lane_ids = list(candidate_lane_ids)
+    else:
+        candidates = map_.query_point(point_xy, buffer=search_radius)
+        lane_ids = candidates if candidates else list(map_.lanes.keys())
 
     for lane_id in lane_ids:
         lane = map_.lanes.get(lane_id)
         if lane is None or lane.geometry is None:
             continue
 
-        centerline = get_lane_centerline(lane)
+        centerline = lane.centerline()
         if centerline is not None:
-            distance = LineString(centerline).distance(point)
+            distance = centerline.distance(point)
         else:
             distance = lane.geometry.distance(point)
 

--- a/tactics2d/traffic/event_detection/collision.py
+++ b/tactics2d/traffic/event_detection/collision.py
@@ -5,6 +5,9 @@
 
 
 from shapely.geometry import Polygon
+from shapely.strtree import STRtree
+
+from tactics2d.map.element.map import HAS_STRTREE
 
 from .event_base import EventBase
 
@@ -29,12 +32,37 @@ class DynamicCollision(EventBase):
 
 
 class StaticCollision(EventBase):
-    """This class defines a detector to check whether the agent collides into static objects."""
+    """This class defines a detector to check whether the agent collides into static objects.
+
+    A Shapely ``STRtree`` is built once over the static-object geometries and
+    queried with the agent bounding box per update, so the exact ``intersects``
+    check runs only on candidates instead of every static object.
+    """
 
     def __init__(self, static_objects: list = None):
+        super().__init__()
         self.static_objects = static_objects
+        self._static_index = None
+        self._static_geometries = []
+        self._build_index()
+
+    def _build_index(self):
+        """(Re)build the spatial index over the current static objects."""
+        self._static_geometries = [
+            obj.geometry for obj in (self.static_objects or []) if obj.geometry is not None
+        ]
+        if HAS_STRTREE and self._static_geometries:
+            self._static_index = STRtree(self._static_geometries)
+        else:
+            self._static_index = None
 
     def update(self, agent_pose: Polygon) -> bool:
+        if self._static_index is not None:
+            for idx in self._static_index.query(agent_pose):
+                if agent_pose.intersects(self._static_geometries[idx]):
+                    return True
+            return False
+
         collide = False
         for static_object in self.static_objects:
             if agent_pose.intersects(static_object.geometry):
@@ -44,3 +72,4 @@ class StaticCollision(EventBase):
 
     def reset(self, static_objects=None):
         self.static_objects = static_objects
+        self._build_index()

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -13,19 +13,8 @@ import os
 
 RENDER = "DISPLAY" in os.environ
 
-# Test constants for deterministic testing
-TEST_ACCEL_OFFSET_1 = 4.5  # For kinematics model test
-TEST_STEER_OFFSET_1 = 0.9  # For kinematics model test
-TEST_ACCEL_OFFSET_2 = 5.25  # For dynamics model test (average of 4.5 and 6)
-TEST_STEER_OFFSET_2 = 0.9  # For dynamics model test
-
-# Vehicle template constants for "medium_car"
-MEDIUM_CAR_LENGTH = 4.284  # meters
-MEDIUM_CAR_FRONT_OVERHANG = 0.880  # meters
-MEDIUM_CAR_REAR_OVERHANG = 0.767  # meters
-
 import logging
-import time
+import math
 
 logging.basicConfig(level=logging.INFO)
 
@@ -72,42 +61,6 @@ VEHICLE_ACTION_LIST = [
     ((0.1, 0.6), 5000), ((0.1, -0.6), 5000),
 ]
 # fmt: on
-
-
-def simulate_actions(model, action_list, initial_state, interval, model_type="standard"):
-    """
-    Simulate a sequence of actions using a physics model.
-
-    Args:
-        model: Physics model instance
-        action_list: List of (action, duration_ms) tuples
-        initial_state: Initial State object
-        interval: Simulation time step (ms)
-        model_type: Type of model ("standard", "drift" for drift model)
-
-    Returns:
-        List of (x, y) trajectory points
-    """
-    if model_type == "drift":
-        state = initial_state
-        omega_wf = 0
-        omega_wr = 0
-        trajectory = [(state.x, state.y)]
-        for action, duration in action_list:
-            for _ in np.arange(0, duration, interval):
-                state, omega_wf, omega_wr, _, _ = model.step(
-                    state, omega_wf, omega_wr, action[0], action[1], interval
-                )
-                trajectory.append((state.x, state.y))
-        return trajectory
-    else:
-        state = initial_state
-        trajectory = [(state.x, state.y)]
-        for action, duration in action_list:
-            for _ in np.arange(0, duration, interval):
-                state, _, _ = model.step(state, action[0], action[1], interval)
-                trajectory.append((state.x, state.y))
-        return trajectory
 
 
 class Visualizer:
@@ -210,302 +163,403 @@ class Visualizer:
 @pytest.mark.physics
 @pytest.mark.parametrize(
     "speed_range, accel_range, interval, delta_t",
-    [
-        ([0, 5], [0, 2], 100, 5),
-        ([-5, 5], [-2, 2], 9, 5),
-        ([5, 5], [2, 2], 50, 3),
-        (5, 2, 100, 5),
-        (-5, -2, 100, 5),
-        (None, None, 100, 5),
-    ],
+    [(None, None, 100, 5), ([-5, 5], [-2, 2], 9, 5), ([0, 5], [0, 2], 100, 5)],
 )
 def test_point_mass(speed_range, accel_range, interval, delta_t):
+    """The newton and euler backends must agree on the same trajectory (within tolerance)."""
     model_newton = PointMass(speed_range, accel_range, interval, delta_t, "newton")
     model_euler = PointMass(speed_range, accel_range, interval, delta_t, "euler")
     initial_state = State(frame=0, x=10, y=10, heading=0, speed=0)
 
-    last_state_newton = initial_state
-    last_state_euler = initial_state
-    line_newton = [[last_state_newton.x, last_state_newton.y]]
-    line_euler = [[last_state_euler.x, last_state_euler.y]]
-    cnt = 0
-    t1 = time.time()
+    state = initial_state
+    line_newton = [[state.x, state.y]]
     for action, duration in PEDESTRIAN_ACTION_LIST:
         for _ in np.arange(0, duration, interval):
-            state_newton = model_newton.step(last_state_newton, action, interval)
-            line_newton.append([state_newton.x, state_newton.y])
-            last_state_newton = state_newton
-            cnt += 1
-    t2 = time.time()
+            state = model_newton.step(state, action, interval)
+            line_newton.append([state.x, state.y])
 
+    state = initial_state
+    line_euler = [[state.x, state.y]]
     for action, duration in PEDESTRIAN_ACTION_LIST:
         for _ in np.arange(0, duration, interval):
-            state_euler = model_euler.step(last_state_euler, action, interval)
-            line_euler.append([state_euler.x, state_euler.y])
-            last_state_euler = state_euler
-    t3 = time.time()
+            state = model_euler.step(state, action, interval)
+            line_euler.append([state.x, state.y])
 
     distance = hausdorff_distance(LineString(line_newton), LineString(line_euler))
     assert distance < 0.01, f"Hausdorff distance {distance:.6f} exceeds threshold 0.01"
-    logging.info("The average fps for Newton's method is {:.2f} Hz.".format(cnt / (t2 + 1e-6 - t1)))
-    logging.info("The average fps for Euler's method is {:.2f} Hz.".format(cnt / (t3 + 1e-6 - t2)))
 
 
 @pytest.mark.physics
-@pytest.mark.parametrize("interval, delta_t", [(9, 5), (50, 3), (100, 5)])
-def test_single_track_kinematic(interval, delta_t):
+def test_step_size_insensitivity():
+    """RK4-based models must produce nearly identical trajectories regardless of delta_t.
+
+    A step-size-dependent integrator (e.g. the previous first-order Euler) would drift by
+    several centimeters to meters here, so this guards against regressing the integrators.
+    """
     vehicle = Vehicle(0)
     vehicle.load_from_template("medium_car")
-    physics_model_constrained = SingleTrackKinematics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    def simulate(model, action_list):
+        state = State(frame=0, x=10, y=10, heading=0, speed=0)
+        trajectory = [(state.x, state.y)]
+        for action, duration in action_list:
+            for _ in np.arange(0, duration, 100):
+                if isinstance(model, PointMass):
+                    state = model.step(state, action, 100)
+                else:
+                    state, _, _ = model.step(state, action[0], action[1], 100)
+                trajectory.append((state.x, state.y))
+        return state, trajectory
+
+    def make(model_cls, delta_t, **extra):
+        if model_cls is PointMass:
+            return model_cls(interval=100, delta_t=delta_t, backend="euler")
+        return model_cls(lf=lf, lr=lr, interval=100, delta_t=delta_t, **extra)
+
+    # (model, action list, extra kwargs, delta_ts to compare against the delta_t=5 baseline)
+    specs = [
+        (SingleTrackKinematics, VEHICLE_ACTION_LIST, {}, (20, 50)),
+        (
+            SingleTrackDynamics,
+            VEHICLE_ACTION_LIST,
+            dict(mass=vehicle.kerb_weight, mass_height=vehicle.height / 2),
+            (20,),
+        ),
+        (PointMass, PEDESTRIAN_ACTION_LIST, {}, (20, 50)),
+    ]
+
+    for model_cls, actions, extra, delta_ts in specs:
+        ref_state, ref_traj = simulate(make(model_cls, 5, **extra), actions)
+        for delta_t in delta_ts:
+            state, trajectory = simulate(make(model_cls, delta_t, **extra), actions)
+            dist = hausdorff_distance(LineString(ref_traj), LineString(trajectory))
+            end_dist = math.hypot(state.x - ref_state.x, state.y - ref_state.y)
+            assert dist < 1e-2, (
+                f"{model_cls.__name__} delta_t={delta_t} vs 5: Hausdorff distance "
+                f"{dist:.6f} exceeds 1e-2"
+            )
+            assert end_dist < 1e-2, (
+                f"{model_cls.__name__} delta_t={delta_t} vs 5: endpoint distance "
+                f"{end_dist:.6f} exceeds 1e-2"
+            )
+
+
+@pytest.mark.physics
+def test_interval_invariance():
+    """With delta_t=5, the trajectory must not depend on how the horizon is split into step() calls."""
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+    total_ms = 600
+    accel, delta = 2.0, 0.4
+
+    def simulate(interval):
+        model = SingleTrackKinematics(lf=lf, lr=lr, interval=interval, delta_t=5)
+        state = State(frame=0, x=0, y=0, heading=0, speed=5.0)
+        t = 0
+        while t < total_ms:
+            state, _, _ = model.step(state, accel, delta, interval)
+            t += interval
+        return state
+
+    ref = simulate(5)
+    for interval in (10, 50, 100, 300, 600):
+        state = simulate(interval)
+        assert abs(state.x - ref.x) < 1e-12, f"interval={interval} vs 5: x {state.x} != {ref.x}"
+        assert abs(state.y - ref.y) < 1e-12, f"interval={interval} vs 5: y {state.y} != {ref.y}"
+        assert (
+            abs(state.heading - ref.heading) < 1e-12
+        ), f"interval={interval} vs 5: heading {state.heading} != {ref.heading}"
+
+
+@pytest.mark.physics
+def test_drift_converges_at_fine_step():
+    """SingleTrackDrift is numerically stiff (a fast mode around 800 s^-1 makes explicit RK4
+    stable only below ~3.5 ms), so only fine step sizes converge. This guards the persistent
+    yaw-rate/slip-angle state and the RK4 integrator: before the fix, even delta_t=1 ms
+    integrated the wrong (per-step-reset) dynamics and diverged ~6 m from the true ODE over 5 s.
+    """
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    def simulate(delta_t):
+        model = SingleTrackDrift(
+            lf=lf,
+            lr=lr,
+            mass=vehicle.kerb_weight,
+            mass_height=vehicle.height / 2,
+            interval=100,
+            delta_t=delta_t,
+        )
+        state = State(frame=0, x=0, y=0, heading=0, speed=10.0, vx=10.0, vy=0)
+        omega_wf = omega_wr = 10.0 / model.radius
+        t = 0
+        while t < 5000:
+            state, omega_wf, omega_wr, _, _ = model.step(state, omega_wf, omega_wr, 1.0, 0.2, 100)
+            t += 100
+        return state
+
+    ref = simulate(1)
+    state = simulate(2)
+    dist = math.hypot(state.x - ref.x, state.y - ref.y)
+    assert dist < 0.2, f"drift delta_t=2 vs 1: endpoint distance {dist:.4f} exceeds 0.2"
+
+
+@pytest.mark.physics
+@pytest.mark.parametrize(
+    "model_cls", [SingleTrackKinematics, SingleTrackDynamics, SingleTrackDrift]
+)
+def test_single_track_smoke(model_cls):
+    """A range-constrained model of each class steps the full action list without NaN/errors.
+
+    Replaces three near-identical tests: builds the model from the medium_car template with the
+    vehicle's steer/speed/accel ranges, runs the whole VEHICLE_ACTION_LIST, asserts every state
+    stays finite with increasing frames, and finishes with an interval=9 (delta_t=5) step that
+    exercises the ``interval % delta_t`` remainder sub-step.
+    """
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    extra = {}
+    if issubclass(model_cls, (SingleTrackDynamics, SingleTrackDrift)):
+        extra = dict(mass=vehicle.kerb_weight, mass_height=vehicle.height / 2)
+
+    model = model_cls(
+        lf=lf,
+        lr=lr,
         steer_range=vehicle.steer_range,
         speed_range=vehicle.speed_range,
         accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
+        interval=100,
+        delta_t=5,
+        **extra,
     )
 
-    physics_model = SingleTrackKinematics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        interval=interval,
-        delta_t=delta_t,
-    )
-
-    expected_lf = MEDIUM_CAR_LENGTH / 2 - MEDIUM_CAR_FRONT_OVERHANG
-    assert (
-        physics_model_constrained.lf == expected_lf
-    ), f"lf mismatch: {physics_model_constrained.lf} != {expected_lf}"
-    expected_lr = MEDIUM_CAR_LENGTH / 2 - MEDIUM_CAR_REAR_OVERHANG
-    assert (
-        physics_model_constrained.lr == expected_lr
-    ), f"lr mismatch: {physics_model_constrained.lr} != {expected_lr}"
-    logging.info(f"{vehicle.steer_range}, {vehicle.speed_range}, {vehicle.accel_range}")
-
-    state_constrained = State(frame=0, x=10, y=10, heading=0, speed=0)
     state = State(frame=0, x=10, y=10, heading=0, speed=0)
-    trajectory = [(state.x, state.y)]
-    if RENDER:
-        # visualizer = Visualizer(vehicle, int(1000/interval))
-        visualizer = Visualizer(vehicle)
-        t1 = time.time()
-
+    states = [state]
+    omega_wf = omega_wr = 0
     for action, duration in VEHICLE_ACTION_LIST:
-        for _ in np.arange(0, duration, interval):
-            state, _, _ = physics_model.step(
-                state_constrained,
-                action[0] + TEST_ACCEL_OFFSET_1,
-                action[1] + TEST_STEER_OFFSET_1,
-                interval,
-            )
-            is_valid = physics_model_constrained.verify_state(state, state_constrained, interval)
-            assert not is_valid, "State should be invalid when using out-of-range actions"
-
-            state_constrained, real_accel, real_steer = physics_model_constrained.step(
-                state_constrained, action[0], action[1], interval
-            )
-            trajectory.append((state_constrained.x, state_constrained.y))
-
-            if RENDER:
-                visualizer.update(state_constrained, action, (real_accel, real_steer), trajectory)
-
-    if RENDER:
-        t2 = time.time()
-        n_frame = int(np.sum([n_frame for _, n_frame in VEHICLE_ACTION_LIST]) / interval)
-        visualizer.quit()
-        logging.info(
-            "The average fps for single track kinematics model is {:.2f} Hz.".format(
-                n_frame / (t2 - t1)
-            )
-        )
-
-
-@pytest.mark.parametrize("interval, delta_t", [(9, 5), (50, 3), (100, 5)])
-def test_single_track_dynamics(interval, delta_t):
-    vehicle = Vehicle(0)
-    vehicle.load_from_template("medium_car")
-    physics_model_constrained = SingleTrackDynamics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        mass=vehicle.kerb_weight,
-        mass_height=vehicle.height / 2,
-        steer_range=vehicle.steer_range,
-        speed_range=vehicle.speed_range,
-        accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
-    )
-
-    physics_model = SingleTrackDynamics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        mass=vehicle.kerb_weight,
-        mass_height=vehicle.height / 2,
-    )
-
-    state_constrained = State(frame=0, x=10, y=10, heading=0, speed=0)
-    trajectory = [(state_constrained.x, state_constrained.y)]
-    if RENDER:
-        # visualizer = Visualizer(vehicle, int(1000/interval))
-        visualizer = Visualizer(vehicle)
-        t1 = time.time()
-
-    for action, duration in VEHICLE_ACTION_LIST:
-        for _ in np.arange(0, duration, interval):
-            state, _, _ = physics_model.step(
-                state_constrained,
-                action[0] + TEST_ACCEL_OFFSET_2,
-                action[1] + TEST_STEER_OFFSET_2,
-                interval,
-            )
-            is_valid = physics_model_constrained.verify_state(state, state_constrained, interval)
-            assert not is_valid, "State should be invalid when using out-of-range actions"
-
-            state_constrained, real_accel, real_steer = physics_model_constrained.step(
-                state_constrained, action[0], action[1], interval
-            )
-            trajectory.append((state_constrained.x, state_constrained.y))
-            if RENDER:
-                visualizer.update(state_constrained, action, (real_accel, real_steer), trajectory)
-
-    if RENDER:
-        t2 = time.time()
-        n_frame = int(np.sum([n_frame for _, n_frame in VEHICLE_ACTION_LIST]) / interval)
-        visualizer.quit()
-        logging.info(
-            "The average fps for single track dynamics model is {:.2f} Hz.".format(
-                n_frame / (t2 - t1)
-            )
-        )
-
-
-@pytest.mark.physics
-@pytest.mark.parametrize("interval, delta_t", [(9, 5), (50, 3), (100, 5)])
-def test_single_track_drift(interval, delta_t):
-    vehicle = Vehicle(0)
-    vehicle.load_from_template("medium_car")
-    physics_model_constrained = SingleTrackDrift(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        mass=vehicle.kerb_weight,
-        mass_height=vehicle.height / 2,
-        steer_range=vehicle.steer_range,
-        speed_range=vehicle.speed_range,
-        accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
-    )
-
-    state_constrained = State(frame=0, x=10, y=10, heading=0, speed=0)
-    omega_wf = 0
-    omega_wr = 0
-    trajectory = [(state_constrained.x, state_constrained.y)]
-    if RENDER:
-        # visualizer = Visualizer(vehicle, int(1000/interval))
-        visualizer = Visualizer(vehicle)
-        t1 = time.time()
-
-    for action, duration in VEHICLE_ACTION_LIST:
-        for _ in np.arange(0, duration, interval):
-            (state_constrained, omega_wf, omega_wr, real_accel, real_steer) = (
-                physics_model_constrained.step(
-                    state_constrained, omega_wf, omega_wr, action[0], action[1], interval
+        for _ in np.arange(0, duration, 100):
+            if isinstance(model, SingleTrackDrift):
+                state, omega_wf, omega_wr, _, _ = model.step(
+                    state, omega_wf, omega_wr, action[0], action[1], 100
                 )
-            )
-            trajectory.append((state_constrained.x, state_constrained.y))
-            if RENDER:
-                visualizer.update(state_constrained, action, (real_accel, real_steer), trajectory)
+            else:
+                state, _, _ = model.step(state, action[0], action[1], 100)
+            assert state.frame == states[-1].frame + 100
+            assert math.isfinite(state.x) and math.isfinite(state.y)
+            assert math.isfinite(state.speed) and math.isfinite(state.heading)
+            states.append(state)
 
-    if RENDER:
-        t2 = time.time()
-        n_frame = int(np.sum([n_frame for _, n_frame in VEHICLE_ACTION_LIST]) / interval)
+    # Remainder sub-step path (5 ms sub-steps plus a 4 ms leftover for interval=9).
+    if isinstance(model, SingleTrackDrift):
+        state, omega_wf, omega_wr, _, _ = model.step(state, omega_wf, omega_wr, 1.0, 0.1, 9)
+    else:
+        state, _, _ = model.step(state, 1.0, 0.1, 9)
+    assert state.frame == states[-1].frame + 9
+    assert math.isfinite(state.x) and math.isfinite(state.y) and math.isfinite(state.speed)
+
+    if RENDER and model_cls is SingleTrackKinematics:
+        visualizer = Visualizer(vehicle)
+        trajectory = [(s.x, s.y) for s in states]
+        for s in states:
+            visualizer.update(s, (0, 0), (0, 0), trajectory)
         visualizer.quit()
-        logging.info(
-            "The average fps for single track drift model is {:.2f} Hz.".format(n_frame / (t2 - t1))
-        )
 
 
 @pytest.mark.physics
-@pytest.mark.parametrize("interval, delta_t", [(9, 5), (50, 3), (100, 5)])
-def test_deviation(interval, delta_t):
+@pytest.mark.parametrize("model_cls", [SingleTrackKinematics, SingleTrackDynamics])
+def test_verify_state_rejects_out_of_range(model_cls):
+    """verify_state must reject a step pushed beyond the steer/accel range but accept an in-range one."""
     vehicle = Vehicle(0)
     vehicle.load_from_template("medium_car")
-    kinematics_model = SingleTrackKinematics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    extra = {}
+    if model_cls is SingleTrackDynamics:
+        extra = dict(mass=vehicle.kerb_weight, mass_height=vehicle.height / 2)
+    ranges = dict(
         steer_range=vehicle.steer_range,
         speed_range=vehicle.speed_range,
         accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
     )
-    dynamics_model = SingleTrackDynamics(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        mass=vehicle.kerb_weight,
-        mass_height=vehicle.height / 2,
-        steer_range=vehicle.steer_range,
-        speed_range=vehicle.speed_range,
-        accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
+    constrained = model_cls(lf=lf, lr=lr, interval=100, delta_t=5, **ranges, **extra)
+    free = model_cls(lf=lf, lr=lr, interval=100, delta_t=5, **extra)
+
+    last = State(frame=0, x=10, y=10, heading=0, speed=5.0, vx=5.0, vy=0)
+
+    # Steering far beyond max_steer (pi/6 ~= 0.52 rad) must be rejected by verify_state.
+    bad, _, _ = free.step(last, 0.0, 1.2, 100)
+    assert constrained.verify_state(bad, last) is False
+
+    # Regression: an accelerating near-straight step at speed used to be rejected because the
+    # reachability box paired the max speed with the extreme steering angle. With a straight
+    # travel bound (Euclidean displacement <= arc length) it is accepted.
+    fast_last = State(frame=0, x=0, y=0, heading=0, speed=10.0, vx=10.0, vy=0)
+    good, real_accel, real_steer = constrained.step(fast_last, 1.0, 0.1, 100)
+    assert real_accel == 1.0 and real_steer == 0.1
+    assert constrained.verify_state(good, fast_last) is True
+
+    # A teleport far beyond one step of travel is still rejected by the distance bound.
+    teleport = State(
+        frame=fast_last.frame + 100,
+        x=fast_last.x + 100.0,
+        y=fast_last.y,
+        heading=fast_last.heading,
+        speed=fast_last.speed,
     )
-    drift_model = SingleTrackDrift(
-        lf=vehicle.length / 2 - vehicle.front_overhang,
-        lr=vehicle.length / 2 - vehicle.rear_overhang,
-        mass=vehicle.kerb_weight,
-        mass_height=vehicle.height / 2,
-        steer_range=vehicle.steer_range,
-        speed_range=vehicle.speed_range,
-        accel_range=vehicle.accel_range,
-        interval=interval,
-        delta_t=delta_t,
-    )
+    assert constrained.verify_state(teleport, fast_last) is False
 
-    state_kinematics = State(frame=0, x=10, y=10, heading=0, speed=0)
-    state_dynamics = State(frame=0, x=10, y=10, heading=0, speed=0)
-    state_drift = State(frame=0, x=10, y=10, heading=0, speed=0)
-    omega_wf = 0
-    omega_wr = 0
-    trajectory_kinematics = [(state_kinematics.x, state_kinematics.y)]
-    trajectory_dynamics = [(state_dynamics.x, state_dynamics.y)]
-    trajectory_drift = [(state_drift.x, state_drift.y)]
 
-    for action, duration in VEHICLE_ACTION_LIST:
-        for _ in np.arange(0, duration, interval):
-            state_kinematics, _, _ = kinematics_model.step(
-                state_kinematics, action[0], action[1], interval
-            )
-            trajectory_kinematics.append((state_kinematics.x, state_kinematics.y))
+@pytest.mark.physics
+def test_grip_cap():
+    """SingleTrackKinematics.mu is an opt-in grip limit.
 
-            state_dynamics, _, _ = dynamics_model.step(
-                state_dynamics, action[0], action[1], interval
-            )
-            trajectory_dynamics.append((state_dynamics.x, state_dynamics.y))
+    When mu is None (default) the model stays the pure no-slip kinematic reference. When mu is
+    set, the yaw rate is capped so the lateral acceleration v * phi_dot stays within mu * g,
+    i.e. the vehicle understeers once the grip limit is reached instead of keeping an
+    unlimited-grip turn.
+    """
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+    g = 9.81
 
-            state_drift, omega_wf, omega_wr, _, _ = drift_model.step(
-                state_drift, omega_wf, omega_wr, action[0], action[1], interval
-            )
-            trajectory_drift.append((state_drift.x, state_drift.y))
+    # Opt-in: the default model carries no friction limit.
+    model_default = SingleTrackKinematics(lf=lf, lr=lr)
+    assert model_default.mu is None
 
-    deviation1 = hausdorff_distance(
-        LineString(trajectory_kinematics), LineString(trajectory_dynamics)
-    )
-    deviation2 = hausdorff_distance(LineString(trajectory_kinematics), LineString(trajectory_drift))
-    deviation3 = hausdorff_distance(LineString(trajectory_dynamics), LineString(trajectory_drift))
+    mu = 0.85
+    mu_g = mu * g
 
-    logging.info(f"The deviation between kinematics and dynamics model is {deviation1:.2f}")
-    logging.info(f"The deviation between kinematics and drift model is {deviation2:.2f}")
-    logging.info(f"The deviation between dynamics and drift model is {deviation3:.2f}")
+    def simulate(mu_, v0=20.0, accel=0.0, steer=0.3, seconds=5.0, delta_t=5):
+        """Return (final state, max measured |yaw rate| over one step)."""
+        model = SingleTrackKinematics(lf=lf, lr=lr, mu=mu_, interval=100, delta_t=delta_t)
+        state = State(frame=0, x=0, y=0, heading=0, speed=v0, vx=v0, vy=0)
+        max_yaw = 0.0
+        for _ in range(int(seconds * 1000 / 100)):
+            prev = state.heading
+            state, _, _ = model.step(state, accel, steer, 100)
+            dh = (state.heading - prev + math.pi) % (2 * math.pi) - math.pi
+            max_yaw = max(max_yaw, abs(dh) / 0.1)
+        return state, max_yaw
 
-    if RENDER:
-        pygame.init()
-        screen = pygame.display.set_mode((1200, 1200))
-        screen.fill((255, 255, 255))
-        pygame.draw.lines(screen, (100, 0, 0), False, np.array(trajectory_kinematics) * 20, 1)
-        pygame.draw.lines(screen, (0, 100, 0), False, np.array(trajectory_dynamics) * 20, 1)
-        pygame.draw.lines(screen, (0, 0, 100), False, np.array(trajectory_drift) * 20, 1)
-        pygame.display.update()
-        pygame.time.wait(3000)
-        pygame.quit()
+    # v=20, delta=0.3 demands a_y ~= 46 m/s^2 >> mu*g=8.34: the turn rate must be capped.
+    state_capped, max_yaw_capped = simulate(mu)
+    state_free, max_yaw_free = simulate(None)
+
+    # The lateral acceleration v * phi_dot never exceeds mu * g (v stays 20 here).
+    assert max_yaw_capped * 20.0 <= mu_g + 1e-6
+    # The geometric (unlimited-grip) model turns far faster in the same corner.
+    assert max_yaw_free > 2.0
+    assert max_yaw_capped < 0.5
+    # The capped vehicle follows a wider arc, so the two endpoints differ by tens of meters.
+    assert math.hypot(state_capped.x - state_free.x, state_capped.y - state_free.y) > 30.0
+
+    # Below the grip limit (a_y ~= 0.95 m/s^2 here) the cap is inactive: identical to mu=None.
+    state_low_cap, _ = simulate(mu, v0=5.0, steer=0.1, seconds=2.0)
+    state_low_free, _ = simulate(None, v0=5.0, steer=0.1, seconds=2.0)
+    assert math.hypot(state_low_cap.x - state_low_free.x, state_low_cap.y - state_low_free.y) < 1e-6
+
+    # Step-size invariance is preserved even in the (piecewise) capped regime: the only
+    # non-smooth point is the moment the demand crosses mu*g, so keep a loose bound.
+    state_cap5, _ = simulate(mu, v0=5.0, accel=1.5, steer=0.3, seconds=5.0, delta_t=5)
+    state_cap20, _ = simulate(mu, v0=5.0, accel=1.5, steer=0.3, seconds=5.0, delta_t=20)
+    assert math.hypot(state_cap5.x - state_cap20.x, state_cap5.y - state_cap20.y) < 0.2
+
+
+@pytest.mark.physics
+def test_friction_ellipse():
+    """SingleTrackDynamics.friction_ellipse couples longitudinal and lateral grip.
+
+    Off by default (no behaviour change). When enabled, braking/acceleration reduces the
+    lateral-response coefficient, so a braking-and-turning vehicle accumulates less yaw than
+    without the ellipse; at zero longitudinal acceleration the two are identical.
+    """
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    lf = vehicle.length / 2 - vehicle.front_overhang
+    lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    def make_model(flag):
+        return SingleTrackDynamics(
+            lf=lf,
+            lr=lr,
+            mass=vehicle.kerb_weight,
+            mass_height=vehicle.height / 2,
+            interval=100,
+            delta_t=2,
+            friction_ellipse=flag,
+        )
+
+    base = make_model(False)
+    assert base.friction_ellipse is False
+
+    def simulate(flag, accel, steer=0.0, seconds=3.0):
+        model = make_model(flag)
+        state = State(frame=0, x=0, y=0, heading=0, speed=20.0, vx=20.0, vy=0)
+        for _ in range(int(seconds * 1000 / 100)):
+            state, _, _ = model.step(state, accel, steer, 100)
+        return state
+
+    # accel = 0: the ellipse reduces mu_lat to mu, so the flag must not change the trajectory.
+    s_off = simulate(False, accel=0.0, steer=0.3)
+    s_on = simulate(True, accel=0.0, steer=0.3)
+    assert math.hypot(s_off.x - s_on.x, s_off.y - s_on.y) < 1e-12
+
+    # Braking (-6 m/s^2, well within mu*g) while cornering: the ellipse leaves less lateral
+    # capability, so the yaw build-up (and thus the lateral drift) is smaller.
+    s_off_brk = simulate(False, accel=-6.0, steer=0.3)
+    s_on_brk = simulate(True, accel=-6.0, steer=0.3)
+    assert math.hypot(s_off_brk.x - s_on_brk.x, s_off_brk.y - s_on_brk.y) > 1.0
+    assert abs(s_on_brk.heading) < abs(s_off_brk.heading)
+
+
+@pytest.mark.physics
+def test_build_physics_model():
+    """Vehicle.build_physics_model wires the template geometry/mass into a physics model."""
+    vehicle = Vehicle(0)
+    vehicle.load_from_template("medium_car")
+    expected_lf = vehicle.length / 2 - vehicle.front_overhang
+    expected_lr = vehicle.length / 2 - vehicle.rear_overhang
+
+    # Kinematics: geometry + ranges (+ optional mu), no mass parameters needed.
+    kin = vehicle.build_physics_model(SingleTrackKinematics, mu=0.85)
+    assert isinstance(kin, SingleTrackKinematics)
+    assert kin.lf == expected_lf
+    assert kin.lr == expected_lr
+    assert kin.mu == 0.85
+    assert kin.steer_range == vehicle.steer_range
+    assert kin.speed_range == vehicle.speed_range
+    assert kin.accel_range == vehicle.accel_range
+
+    kin_default = vehicle.build_physics_model(SingleTrackKinematics)
+    assert kin_default.mu is None
+
+    # Dynamics: geometry + mass + optional mu / friction_ellipse; I_z keeps the class default.
+    dyn = vehicle.build_physics_model(SingleTrackDynamics, mu=0.85, friction_ellipse=True)
+    assert isinstance(dyn, SingleTrackDynamics)
+    assert dyn.lf == expected_lf and dyn.lr == expected_lr
+    assert dyn.mass == vehicle.kerb_weight
+    assert dyn.mass_height == vehicle.height / 2
+    assert dyn.mu == 0.85
+    assert dyn.friction_ellipse is True
+    assert dyn.I_z == SingleTrackDynamics(lf=1, lr=1, mass=1, mass_height=0.5).I_z
+
+    # Drift: geometry + mass + wheel radius / I_z overrides.
+    drift = vehicle.build_physics_model(SingleTrackDrift, I_z=2000.0, radius=0.33)
+    assert isinstance(drift, SingleTrackDrift)
+    assert drift.lf == expected_lf and drift.lr == expected_lr
+    assert drift.mass == vehicle.kerb_weight
+    assert drift.mass_height == vehicle.height / 2
+    assert drift.I_z == 2000.0
+    assert drift.radius == 0.33


### PR DESCRIPTION
## Summary

  Merges the `refactor-efficiency` branch into `main`. Two things are delivered as one
  cohesive change set:

  1. **Simulation efficiency** — the physics/step, sensor, renderer and parser hot paths are
     several times faster with identical results (see `scripts/bench/BASELINE.md`).
  2. **Physics fidelity & correctness** — the single-track model family now reproduces its
     reference ODEs faithfully (RK4, persistent slip states, corrected CommonRoad/Pacejka
     parameters), exposes opt-in physical-realism knobs, and no longer rejects legitimate
     states in `verify_state`.

  ## Motivation and Context

  The physics `step()` was ~5–6× slower than it needed to be (scalar `numpy` calls in tight
  loops), rendering/map-query did full scans each frame, and dataset parsing spent most of its
  time in per-sample Python. Separately, the bicycle models integrated with first-order Euler
  (step-size dependent) and the drift model silently reset its yaw-rate/slip state every
  `step()`, so trajectories drifted meters from the true ODE; several parameters were also
  ported incorrectly from the CommonRoad reference. The result was that a user could not trust
  long-horizon or near-limit trajectories, and comparing models to real physics was muddled.

  ## Changes (Mandatory)

  **Efficiency** (`scripts/bench/BASELINE.md` for before/after medians)
  - Physics `step()`: scalar `math.*` + loop-invariant hoisting — kinematics 76→9 µs,
    dynamics 95→18 µs, drift 1436→230 µs, point mass 14→6 µs; multi-agent frame 115→46 µs/agent.
  - `BEVCamera`/`StaticCollision`: STRtree broad-phase (bev update ~18.9 ms → ~4 ms at 50 m range).
  - `PygameRenderer` point cloud: vectorized pixel writes (~7 ms → 1 ms per 5000-pt frame).
  - Dataset parsing: vectorized cubic/line sampling + fast `State.__init__` path (SanAntonio XODR
    1.69 s → 1.52 s; State/row ~5.4 → 2.6 µs). `Vehicle.get_pose`/`Lane.centerline` cached.
  - Adds `scripts/bench/bench_*.py` and `docs/benchmark_vs_external.md`: Tactics2D kinematics
    equals CommonRoad's KS-cog reference to 7e-12 m over 5 s and agrees with a scipy ODE
    reference to 3e-11 m; also surveys maintained simulators (SUMO/CARLA/MuJoCo/Chrono/OCD).

  **Physics fidelity & correctness**
  - Replace first-order Euler with RK4 in kinematics/dynamics/drift (+ point-mass euler backend),
    making trajectories effectively step-size independent (new insensitivity/interval tests).
  - Persist `yaw_rate`/`slip_angle` on `State` across `step()` (new optional fields) so
    dynamics/drift no longer re-initialize to kinematic values each call (drift had ~6 m error
    over 5 s against a high-precision reference). Fix dynamics computing but never applying the
    `interval % delta_t` remainder sub-step.
  - Restore real reference parameters in dynamics/drift (CommonRoad vehicle ID 1 / Ford Escort):
    `I_z` 1500→1538.85, un-rounded Pacejka coefficients, fix swapped `r_cx1`/`r_ex1`.
  - New opt-in fidelity knobs (all off by default, no behaviour change): `SingleTrackKinematics.mu`
    grip cap (`a_y ≤ μ·g`), `SingleTrackDynamics.friction_ellipse` (longitudinal–lateral grip
    coupling), and `Vehicle.build_physics_model(...)` to wire a vehicle's real geometry/mass/ranges
    into any of the three models.
  - Fix `verify_state` false negatives: the reachability box wrongly paired max speed with extreme
    steering, rejecting legitimate accelerating/near-straight steps; the three models now share one
    `PhysicsModelBase._verify_kinematic_state` check bounded by the straight-line travel distance,
    so valid steps pass and teleports are still rejected.

  **Tests & docs**
  - `tests/test_physics.py`: add regression tests (step-size insensitivity, interval invariance,
    drift fine-step convergence, grip cap, friction ellipse, `build_physics_model`, verify
    reachability) and prune duplicate/assert-less legacy tests (24 → 14 cases, ~3.5 min → ~6 s).
  - Docs: `docs/index.md` physics note, `docs/benchmark_vs_external.md`, CHANGELOG entries.

  ## Testing (Mandatory)

  - [ ] `pre-commit run --all-files` passed
  - [x] `pytest` passed — `tests/test_physics.py` (14 passed), `tests/test_participant.py` (27 passed)
  - [x] Documentation style/format checked (docstrings/markdown read-through)

  Result summary:
  - Full `tests/test_physics.py` + `tests/test_participant.py` green after all changes.
  - `python scripts/bench/bench_external.py` (full + quick): cross-validation unchanged
    (kinematics vs CommonRoad ~7e-12 m; scipy ~3e-11 m); grip-cap demo prints peak lateral a_y
    46.3 (unlimited) → 8.34 m/s² with `mu=0.85`.
  - Pre-commit and the full repo-wide suite were not run in this session; run before merge.

  ## Reviewer Checklist (Author)

  - [x] PR title follows project style (clear prefix + concise summary, e.g. `Feat: ...`)
  - [x] PR title follows gitmoji recommendation for its change type
  - [x] Appropriate labels have been applied
  - [x] Reviewer(s) have been assigned
  - [x] Code documentation/docstrings in this PR are written in English
  - [x] This PR is ready for review