### PR TITLE
feat(map): expose vehicle lane semantics

### DIFF
--- a/tactics2d/map/element/lane.py
+++ b/tactics2d/map/element/lane.py
@@ -84,6 +84,21 @@ class Lane:
     )
 
     _speed_units = ["km/h", "mi/h", "m/s", "mph"]
+    _non_vehicle_subtypes = frozenset(
+        {
+            "bicycle_lane",
+            "crosswalk",
+            "cycleway",
+            "exit",
+            "footway",
+            "pedestrian",
+            "shared_walkway",
+            "sidewalk",
+            "stairs",
+            "stairway",
+            "walkway",
+        }
+    )
 
     def __init__(
         self,
@@ -248,6 +263,12 @@ class Lane:
         return LaneProjection(
             s=progress, d=sign * distance, point=projected, heading=heading, distance=distance
         )
+
+    def is_vehicle_lane(self) -> bool:
+        """Return whether the lane is suitable for vehicle routing."""
+
+        subtype = str(self.subtype or "").strip().lower()
+        return subtype not in self._non_vehicle_subtypes
 
     def is_related(self, id_: str) -> LaneRelationship:
         """Check if a given lane is related to the lane

--- a/tests/test_map_element.py
+++ b/tests/test_map_element.py
@@ -65,6 +65,24 @@ def test_lane():
 
 
 @pytest.mark.map_element
+@pytest.mark.parametrize(
+    ("subtype", "expected"),
+    [
+        (None, True),
+        ("road", True),
+        (" Highway ", True),
+        ("bicycle_lane", False),
+        ("WALKWAY", False),
+        ("crosswalk", False),
+    ],
+)
+def test_lane_vehicle_semantics(subtype, expected):
+    lane = map_element.Lane(id_="lane", subtype=subtype)
+
+    assert lane.is_vehicle_lane() is expected
+
+
+@pytest.mark.map_element
 def test_junction():
     connection1 = map_element.Junction(
         id_="1", incoming_road="2", connecting_road="3", contact_point="start", lane_links=[]


### PR DESCRIPTION
将车道是否适合车辆通行的语义判断整合到 Lane.is_vehicle_lane()，并补充对应的 Lane 测试。仅包含 lane.py 与 test_map_element.py；保留原有测试，不包含脚本、数据或 LimSim 实验文件。相关测试已通过。